### PR TITLE
Add option to disable blur while screen is locked

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/UserPresentReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/UserPresentReceiver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.preference.PreferenceManager;
+
+import de.greenrobot.event.EventBus;
+
+public class UserPresentReceiver extends BroadcastReceiver {
+    public static final String PREF_ENABLED = "disable_blur_when_screen_locked_enabled";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent != null) {
+            if (!PreferenceManager.getDefaultSharedPreferences(context)
+                    .getBoolean(PREF_ENABLED, false)) {
+                EventBus.getDefault().post(new UserPresent(true));
+            } else {
+                if (Intent.ACTION_USER_PRESENT.equals(intent.getAction())) {
+                    EventBus.getDefault().post(new UserPresent(true));
+                } else if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                    EventBus.getDefault().post(new UserPresent(false));
+                }
+            }
+        }
+    }
+
+    public static class UserPresent {
+
+        public boolean present = false;
+
+        public UserPresent(boolean present) {
+            this.present = present;
+        }
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsAdvancedFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsAdvancedFragment.java
@@ -29,6 +29,7 @@ import android.widget.CompoundButton;
 import android.widget.SeekBar;
 
 import com.google.android.apps.muzei.NewWallpaperNotificationReceiver;
+import com.google.android.apps.muzei.UserPresentReceiver;
 import com.google.android.apps.muzei.event.BlurAmountChangedEvent;
 import com.google.android.apps.muzei.event.DimAmountChangedEvent;
 import com.google.android.apps.muzei.render.MuzeiBlurRenderer;
@@ -45,6 +46,7 @@ public class SettingsAdvancedFragment extends Fragment {
     private SeekBar mBlurSeekBar;
     private SeekBar mDimSeekBar;
     private CheckBox mNotifyNewWallpaperCheckBox;
+    private CheckBox mDisableBlurWhenScreenLockedCheckBox;
 
     public SettingsAdvancedFragment() {
     }
@@ -111,6 +113,22 @@ public class SettingsAdvancedFragment extends Fragment {
                 });
         mNotifyNewWallpaperCheckBox.setChecked(getSharedPreferences()
                 .getBoolean(NewWallpaperNotificationReceiver.PREF_ENABLED, true));
+
+        mDisableBlurWhenScreenLockedCheckBox = (CheckBox) rootView.findViewById(
+                R.id.disable_blur_when_locked_checkbox);
+        mDisableBlurWhenScreenLockedCheckBox.setOnCheckedChangeListener(
+                new CompoundButton.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(CompoundButton button, boolean checked) {
+                        getSharedPreferences().edit()
+                                .putBoolean(UserPresentReceiver.PREF_ENABLED, checked)
+                                .apply();
+                        EventBus.getDefault().post(new BlurAmountChangedEvent());
+                    }
+                }
+        );
+        mDisableBlurWhenScreenLockedCheckBox.setChecked(getSharedPreferences()
+                .getBoolean(UserPresentReceiver.PREF_ENABLED, true));
         return rootView;
     }
 

--- a/main/src/main/res/layout/settings_advanced_fragment_include_content.xml
+++ b/main/src/main/res/layout/settings_advanced_fragment_include_content.xml
@@ -76,4 +76,18 @@
         android:paddingLeft="4dp"
         android:text="@string/settings_notify_new_wallpaper" />
 
+    <CheckBox android:id="@+id/disable_blur_when_locked_checkbox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:layout_marginLeft="8dp"
+        android:layout_alignLeft="@id/dim_amount"
+        android:layout_alignRight="@id/dim_amount"
+        android:layout_below="@id/notify_new_wallpaper_checkbox"
+        android:textSize="@dimen/settings_text_size_normal"
+        android:fontFamily="sans-serif-condensed"
+        android:textColor="#fff"
+        android:paddingLeft="4dp"
+        android:text="@string/settings_disable_blur_when_locked" />
+
 </RelativeLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="settings_blur_amount_title">Blur</string>
     <string name="settings_dim_amount_title">Dim</string>
     <string name="settings_notify_new_wallpaper">New wallpaper notifications</string>
+    <string name="settings_disable_blur_when_locked">Disable blur while screen is locked</string>
 
     <string name="notification_new_wallpaper">New wallpaper</string>
 


### PR DESCRIPTION
I was perusing the reviews on the Play Store when I noticed someone mentioning they'd like the ability to see the artwork in its full, unblurred glory while the keyguard is up and blurring once more when the screen is unlocked. Seemed simple enough so I whipped this up.
