### PR TITLE
Fix advanced preference layout issue

### DIFF
--- a/main/src/main/res/layout/settings_advanced_fragment_include_content.xml
+++ b/main/src/main/res/layout/settings_advanced_fragment_include_content.xml
@@ -14,66 +14,66 @@
   limitations under the License.
   -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:stretchColumns="1">
 
-    <TextView android:id="@+id/blur_amount_label"
-        android:layout_width="wrap_content"
-        android:layout_height="32dp"
-        android:gravity="center_vertical|right"
-        android:textSize="@dimen/settings_text_size_normal"
-        android:fontFamily="sans-serif-condensed"
-        android:textAllCaps="true"
-        android:textColor="#fff"
-        android:textStyle="bold"
-        android:text="@string/settings_blur_amount_title" />
+    <TableRow>
+        <TextView android:id="@+id/blur_amount_label"
+                  android:layout_width="wrap_content"
+                  android:layout_height="32dp"
+                  android:gravity="center_vertical|right"
+                  android:textSize="@dimen/settings_text_size_normal"
+                  android:fontFamily="sans-serif-condensed"
+                  android:textAllCaps="true"
+                  android:textColor="#fff"
+                  android:textStyle="bold"
+                  android:lines="1"
+                  android:text="@string/settings_blur_amount_title" />
 
-    <SeekBar style="@style/Settings.Widget.SeekBar.BlurAmount"
-        android:id="@+id/blur_amount"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/blur_amount_label"
-        android:layout_alignParentRight="true"
-        android:layout_alignTop="@id/blur_amount_label"
-        android:max="500" />
+        <SeekBar style="@style/Settings.Widget.SeekBar.BlurAmount"
+                 android:id="@+id/blur_amount"
+                 android:layout_width="0dp"
+                 android:layout_weight="1"
+                 android:layout_height="wrap_content"
+                 android:layout_gravity="fill_horizontal|center_vertical"
+                 android:max="500" />
+    </TableRow>
 
-    <TextView android:id="@+id/dim_amount_label"
-        android:layout_width="wrap_content"
-        android:layout_height="32dp"
-        android:layout_marginTop="16dp"
-        android:layout_below="@id/blur_amount_label"
-        android:layout_alignLeft="@id/blur_amount_label"
-        android:layout_alignRight="@id/blur_amount_label"
-        android:gravity="center_vertical|right"
-        android:textSize="@dimen/settings_text_size_normal"
-        android:fontFamily="sans-serif-condensed"
-        android:textAllCaps="true"
-        android:textColor="#fff"
-        android:textStyle="bold"
-        android:text="@string/settings_dim_amount_title" />
+    <TableRow
+            android:layout_marginTop="16dp">
 
-    <SeekBar style="@style/Settings.Widget.SeekBar.DimAmount"
-        android:id="@+id/dim_amount"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_alignLeft="@id/blur_amount"
-        android:layout_alignRight="@id/blur_amount"
-        android:layout_alignTop="@id/dim_amount_label"
-        android:max="255" />
+        <TextView android:id="@+id/dim_amount_label"
+                  android:layout_width="wrap_content"
+                  android:layout_height="32dp"
+                  android:gravity="center_vertical|right"
+                  android:textSize="@dimen/settings_text_size_normal"
+                  android:fontFamily="sans-serif-condensed"
+                  android:textAllCaps="true"
+                  android:textColor="#fff"
+                  android:textStyle="bold"
+                  android:lines="1"
+                  android:text="@string/settings_dim_amount_title" />
+
+        <SeekBar style="@style/Settings.Widget.SeekBar.DimAmount"
+                 android:id="@+id/dim_amount"
+                 android:layout_width="0dp"
+                 android:layout_weight="1"
+                 android:layout_height="wrap_content"
+                 android:layout_gravity="fill_horizontal|center_vertical"
+                 android:max="255" />
+    </TableRow>
 
     <CheckBox android:id="@+id/notify_new_wallpaper_checkbox"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:layout_marginLeft="8dp"
-        android:layout_alignLeft="@id/dim_amount"
-        android:layout_alignRight="@id/dim_amount"
-        android:layout_below="@id/dim_amount"
-        android:textSize="@dimen/settings_text_size_normal"
-        android:fontFamily="sans-serif-condensed"
-        android:textColor="#fff"
-        android:paddingLeft="4dp"
-        android:text="@string/settings_notify_new_wallpaper" />
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginTop="24dp"
+              android:layout_marginLeft="8dp"
+              android:textSize="@dimen/settings_text_size_normal"
+              android:fontFamily="sans-serif-condensed"
+              android:textColor="#fff"
+              android:paddingLeft="4dp"
+              android:text="@string/settings_notify_new_wallpaper" />
 
-</RelativeLayout>
+</TableLayout>


### PR DESCRIPTION
I am localizing the app in Italian and I found a little issue with the Advanced settings layout.

As it is right now, the labels (blur & dim) are in a `RelativeLayout` and their size is determined by the blur label size. This means that, if the dim label is longer (as is in Italian), the dim label gets cut and wraps to a new line.

I had to change the advanced preferences fragment layout include to using a `TableLayout`, and also added `lines='1'` attribute to the `TextView`s.
