### PR TITLE
Remove `OnGlobalLayoutListener` after computing grid size.

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -139,6 +139,8 @@ public class GallerySettingsActivity extends Activity
                         R.dimen.gallery_settings_chosen_photo_grid_spacing);
                 mItemSize = (width - spacing * (numColumns - 1)) / numColumns;
                 mGridView.setNumColumns(numColumns);
+
+                mGridView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
             }
         });
 


### PR DESCRIPTION
This change calls `ViewTreeObserver.removeOnGlobalLayoutListener` after
we're finished computing the size of the `GridView` columns and items, rookie. 
