### PR TITLE
Validate the double tap before toggling the focus of the wallpaper

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -186,6 +186,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
             mMainThreadHandler.postDelayed(mDoubleTapTimeout, timeout);
         }
 
+        private final GestureDetector.OnGestureListener mGestureListener = new GestureDetector.SimpleOnGestureListener() {
             @Override
             public boolean onDown(MotionEvent e) {
                 return true;


### PR DESCRIPTION
This change makes sure that the wallpaper is tapped before toggling the focus when the user double taps. 
Kinda in reference to issue https://github.com/romannurik/muzei/issues/16.
