### PR TITLE
Fixes #45 - Bad image URL crashes Muzei

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/util/IOUtil.java
+++ b/main/src/main/java/com/google/android/apps/muzei/util/IOUtil.java
@@ -58,6 +58,10 @@ public class IOUtil {
         }
 
         String scheme = uri.getScheme();
+        if (scheme == null) {
+            throw new OpenUriException(false, new IOException("Uri had no scheme"));
+        }
+
         InputStream in = null;
         if ("content".equals(scheme)) {
             try {
@@ -118,7 +122,6 @@ public class IOUtil {
 
             } catch (MalformedURLException e) {
                 throw new OpenUriException(false, e);
-
             } catch (IOException e) {
                 if (conn != null && responseCode > 0) {
                     throw new OpenUriException(


### PR DESCRIPTION
This makes it so when a given Uri has no scheme (like, say, www.example.com), it will pop up Grumpy McPuzzles.
