### PR TITLE
Replaced deprecated 'setServer()' with 'setEndpoint()'

### DIFF
--- a/example-source-500px/src/main/java/com/example/muzei/examplesource500px/FiveHundredPxExampleArtSource.java
+++ b/example-source-500px/src/main/java/com/example/muzei/examplesource500px/FiveHundredPxExampleArtSource.java
@@ -55,7 +55,7 @@ public class FiveHundredPxExampleArtSource extends RemoteMuzeiArtSource {
         String currentToken = (getCurrentArtwork() != null) ? getCurrentArtwork().getToken() : null;
 
         RestAdapter restAdapter = new RestAdapter.Builder()
-                .setServer("https://api.500px.com")
+                .setEndpoint("https://api.500px.com")
                 .setRequestInterceptor(new RequestInterceptor() {
                     @Override
                     public void intercept(RequestFacade request) {


### PR DESCRIPTION
setServer() has been deprecated and it is removed from retrfit v1.5. So i have changed it to setEndpoint(). According to retrofit setEndpoint() is the replacement for setServer(). 
