### PR TITLE
Make keystore.props.file local.properties' entry optional

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -61,9 +61,10 @@ android {
             def Properties localProps = new Properties()
             localProps.load(new FileInputStream(file('../local.properties')))
             def Properties keyProps = new Properties()
-            assert localProps['keystore.props.file'];
-            keyProps.load(new FileInputStream(file(localProps['keystore.props.file'])))
-            storeFile file(keyProps["store"])
+            if (localProps['keystore.props.file'] != null) {
+                keyProps.load(new FileInputStream(file(localProps['keystore.props.file'])))
+            }
+            storeFile keyProps["store"] != null ? file(keyProps["store"]) : null
             keyAlias keyProps["alias"]
             storePassword keyProps["storePass"]
             keyPassword keyProps["pass"]


### PR DESCRIPTION
A stumbling block for any Muzei developer who initially tries to checkout and then import Muzei into Android Studio is that the keystore.props.file entry in local.properties is required, causing the import to error out until you 1) figure out why the error occurred and 2) figure out how to fix it.

As there are few, if any, Muzei developers who need to build a release build (the only time when these values are actually required), we can make the keystore.props.file value optional, allowing new developers to immediately checkout, import, and build a debug APK without issue.

Building a release build with a null storeFile will error out the build as expected, but in that case the developer is more likely to know where to look - in the signingConfig.releaseConfig section which defines this loading behavior.
