### PR TITLE
Ensure GLPicture loading does not freeze on low blur amounts

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
@@ -339,13 +339,13 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
                 tempBitmap.recycle();
 
                 // Create the GLPicture objects
-                ImageBlurrer blurrer = new ImageBlurrer(mContext);
                 mPictures[0] = new GLPicture(bitmapRegionLoader, mHeight);
                 if (mMaxPrescaledBlurPixels == 0) {
                     for (int f = 1; f <= mBlurKeyframes; f++) {
                         mPictures[f] = mPictures[0];
                     }
                 } else {
+                    ImageBlurrer blurrer = new ImageBlurrer(mContext);
                     // To blur, first load the entire bitmap region, but at a very large
                     // sample size that's appropriate for the final blurred image
                     options.inSampleSize = ImageUtil.calculateSampleSize(
@@ -379,8 +379,8 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
                     }
 
                     scaledBitmap.recycle();
+                    blurrer.destroy();
                 }
-                blurrer.destroy();
             }
 
             recomputeTransformMatrices();


### PR DESCRIPTION
On some devices such as the Nexus 10 and Samsung Galaxy Note 2014, when you use a low amount of blur (triggering the mMaxPrescaledBlurPixels == 0 case), blurrer.destroy() freezes the app, causing images to no longer load until you force stop the app. As the ImageBlurrer is not actually needed unless mMaxPrescaledBlurPixels is greater than 0, we can move the allocation and destruction of it inside the else block. This ensures that the app works as expected in either case.

Fixes #63 
