### PR TITLE
Update Gradle and Build Tools to latest releases

### DIFF
--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -19,11 +19,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:0.13.+'
     }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 repositories {
     mavenCentral()
@@ -37,7 +37,7 @@ dependencies {
 
 android {
     compileSdkVersion 20
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "20.0.0"
 
     defaultConfig {
         minSdkVersion 17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 05 19:20:13 EST 2013
+#Thu Oct 09 10:09:32 PDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,11 +19,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:0.13.+'
     }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 project.archivesBaseName = "muzei"
 
@@ -43,7 +43,7 @@ dependencies {
 
 android {
     compileSdkVersion 20
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "20.0.0"
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))


### PR DESCRIPTION
Gradle Plugin to 0.13.0, Gradle to 2.1, Build Tools to 20.0.0, Android plugin renamed to new 'com.android.application'.

This will ensure that Muzei compile and build out of the box on Android Studio 0.8.11 (which is now the minimum compatible version).
