### PR TITLE
Implement Android 5.0 notification color and public version

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -115,6 +115,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
 
         NotificationCompat.Builder nb = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_stat_muzei)
+                .setColor(context.getResources().getColor(R.color.notification))
                 .setPriority(Notification.PRIORITY_MIN)
                 .setAutoCancel(true)
                 .setContentTitle(artwork.getTitle())
@@ -127,14 +128,34 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
                         new Intent(context, NewWallpaperNotificationReceiver.class)
                                 .setAction(ACTION_MARK_NOTIFICATION_READ),
                         PendingIntent.FLAG_UPDATE_CURRENT));
-        NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle(nb)
+        NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle()
                 .bigLargeIcon(null)
                 .setBigContentTitle(artwork.getTitle())
                 .setSummaryText(artwork.getByline())
                 .bigPicture(largeIcon);
+        nb.setStyle(style);
+
+        // Hide the image and artwork title for the public version
+        NotificationCompat.Builder publicBuilder = new NotificationCompat.Builder(context)
+                .setSmallIcon(R.drawable.ic_stat_muzei)
+                .setColor(context.getResources().getColor(R.color.notification))
+                .setPriority(Notification.PRIORITY_MIN)
+                .setAutoCancel(true)
+                .setContentTitle(context.getString(R.string.app_name))
+                .setContentText(context.getString(R.string.notification_new_wallpaper))
+                .setContentIntent(PendingIntent.getActivity(context, 0,
+                        Intent.makeMainActivity(new ComponentName(context, MuzeiActivity.class)),
+                        PendingIntent.FLAG_UPDATE_CURRENT))
+                .setDeleteIntent(PendingIntent.getBroadcast(context, 0,
+                        new Intent(context, NewWallpaperNotificationReceiver.class)
+                                .setAction(ACTION_MARK_NOTIFICATION_READ),
+                        PendingIntent.FLAG_UPDATE_CURRENT));
+        nb.setPublicVersion(publicBuilder.build());
+
+
         NotificationManager nm = (NotificationManager) context.getSystemService(
                 Context.NOTIFICATION_SERVICE);
-        nm.notify(NOTIFICATION_ID, style.build());
+        nm.notify(NOTIFICATION_ID, nb.build());
 
         // Clear any last-seen notification
         sp.edit().remove(PREF_LAST_SEEN_NOTIFICATION_IMAGE_URI).apply();

--- a/main/src/main/res/values/colors.xml
+++ b/main/src/main/res/values/colors.xml
@@ -15,6 +15,8 @@
   -->
 
 <resources>
+    <color name="notification">#607d8b</color>
+
     <color name="gallery_settings_empty_state_dark">#394a43</color>
     <color name="gallery_settings_empty_state_light">#639680</color>
 


### PR DESCRIPTION
Notifications in Android 5.0 can have a background color over the small icon and can specify a separate public and private version (where potentially sensitive details can be hidden from the public version). This implements both features, using a blue grey color matching the system apps' notification color and hiding the image and the artwork title from the public version.
