### PR TITLE
Optimize notification large icon and Android Wear background sizes

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -17,7 +17,6 @@
 package com.google.android.apps.muzei;
 
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -29,6 +28,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Rect;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 import android.text.TextUtils;
 
 import com.google.android.apps.muzei.api.Artwork;
@@ -73,8 +73,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         sp.edit().putString(PREF_LAST_SEEN_NOTIFICATION_IMAGE_URI,
                 currentArtwork.getImageUri().toString()).apply();
 
-        NotificationManager nm = (NotificationManager) context.getSystemService(
-                Context.NOTIFICATION_SERVICE);
+        NotificationManagerCompat nm = NotificationManagerCompat.from(context);
         nm.cancel(NOTIFICATION_ID);
     }
 
@@ -110,8 +109,15 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         }
 
         BitmapFactory.Options options = new BitmapFactory.Options();
-        options.inSampleSize = ImageUtil.calculateSampleSize(height, 256);
+        int largeIconHeight = context.getResources()
+                .getDimensionPixelSize(android.R.dimen.notification_large_icon_height);
+        options.inSampleSize = ImageUtil.calculateSampleSize(height, largeIconHeight);
         Bitmap largeIcon = bitmapRegionLoader.decodeRegion(rect, options);
+
+        // Use the suggested 400x400 for Android Wear background images per
+        // http://developer.android.com/training/wearables/notifications/creating.html#AddWearableFeatures
+        options.inSampleSize = ImageUtil.calculateSampleSize(height, 400);
+        Bitmap background = bitmapRegionLoader.decodeRegion(rect, options);
 
         NotificationCompat.Builder nb = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_stat_muzei)
@@ -132,7 +138,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
                 .bigLargeIcon(null)
                 .setBigContentTitle(artwork.getTitle())
                 .setSummaryText(artwork.getByline())
-                .bigPicture(largeIcon);
+                .bigPicture(background);
         nb.setStyle(style);
 
         // Hide the image and artwork title for the public version
@@ -153,8 +159,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         nb.setPublicVersion(publicBuilder.build());
 
 
-        NotificationManager nm = (NotificationManager) context.getSystemService(
-                Context.NOTIFICATION_SERVICE);
+        NotificationManagerCompat nm = NotificationManagerCompat.from(context);
         nm.notify(NOTIFICATION_ID, nb.build());
 
         // Clear any last-seen notification


### PR DESCRIPTION
Large icon size is set by android.R.dimen.notification_large_icon_height and changed between pre-Android 5.0 and 5.0. To ensure the best large icon, we use the provided dimension - Android by default does not center crop too large of images so the fixed size was giving strange results, particularly on low resolution devices.

While there isn't a set size for BigPictureStyle backgrounds, this background is used on Android Wear devices, which suggest a 400x400px background per http://developer.android.com/training/wearables/notifications/creating.html#AddWearableFeatures - we load a separate background image of this size.
