### PR TITLE
Add Intent Filter to link directly to notification settings on Android 5...

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -63,7 +63,12 @@
         <activity android:name="com.google.android.apps.muzei.settings.SettingsActivity"
             android:label="@string/settings_title"
             android:theme="@style/Theme.Muzei.Settings"
-            android:exported="true" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name="com.google.android.apps.muzei.settings.AboutActivity"

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.app.Notification;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -77,16 +78,18 @@ public class SettingsActivity extends Activity implements SettingsChooseSourceFr
     private int mStartSection = START_SECTION_SOURCE;
 
     private ObjectAnimator mBackgroundAnimator;
-    private View mContainerView;
     private boolean mPaused;
     private boolean mRenderLocally;
 
     public void onCreate(Bundle savedInstanceState) {
         requestWindowFeature(Window.FEATURE_ACTION_BAR);
         super.onCreate(savedInstanceState);
-
         setContentView(R.layout.settings_activity);
-        mContainerView = findViewById(R.id.content_container);
+
+        if (getIntent() != null && getIntent().getCategories() != null &&
+                getIntent().getCategories().contains(Notification.INTENT_CATEGORY_NOTIFICATION_PREFERENCES)) {
+            mStartSection = START_SECTION_ADVANCED;
+        }
 
         // Set up UI widgets
         setupActionBar();


### PR DESCRIPTION
....0+ devices

Per [Cyril Mottier's G+ post](https://plus.google.com/+CyrilMottier/posts/YY6tbJrJMra), Android 5.0 adds the ability to directly link to an application's notification settings when long pressing on the notification. Adding this functionality allows users to directly jump to Muzei's notification settings (part of the Advanced settings screen) from the notification.
