### PR TITLE
Default to app name for notification title if there is no artwork title

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -156,12 +156,15 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         options.inSampleSize = ImageUtil.calculateSampleSize(height, 400);
         Bitmap background = bitmapRegionLoader.decodeRegion(rect, options);
 
+        String title = TextUtils.isEmpty(artwork.getTitle())
+                ? context.getString(R.string.app_name)
+                : artwork.getTitle();
         NotificationCompat.Builder nb = new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_stat_muzei)
                 .setColor(context.getResources().getColor(R.color.notification))
                 .setPriority(Notification.PRIORITY_MIN)
                 .setAutoCancel(true)
-                .setContentTitle(artwork.getTitle())
+                .setContentTitle(title)
                 .setContentText(context.getString(R.string.notification_new_wallpaper))
                 .setLargeIcon(largeIcon)
                 .setContentIntent(PendingIntent.getActivity(context, 0,
@@ -173,7 +176,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
                         PendingIntent.FLAG_UPDATE_CURRENT));
         NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle()
                 .bigLargeIcon(null)
-                .setBigContentTitle(artwork.getTitle())
+                .setBigContentTitle(title)
                 .setSummaryText(artwork.getByline())
                 .bigPicture(background);
         nb.setStyle(style);


### PR DESCRIPTION
Previously notifications for artwork with no title would have an empty title but 'New wallpaper' as its text, which looks really weird, particularly on Android Wear devices. Instead, we use the app name in place of an empty title which ensures the notification looks correct even if there is no title associated with the artwork.

Tested with Muzei Ghibli: https://play.google.com/store/apps/details?id=net.ebt.muzei.miyazaki
