### PR TITLE
Update to RetroFit 1.7.1, fix compilation issues with 500px example

### DIFF
--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.squareup.retrofit:retrofit:1.3.0'
+    compile 'com.squareup.retrofit:retrofit:1.7.1'
     //compile 'com.google.android.apps.muzei:muzei-api:+'
     compile project(':api')
 }

--- a/example-source-500px/src/main/java/com/example/muzei/examplesource500px/FiveHundredPxExampleArtSource.java
+++ b/example-source-500px/src/main/java/com/example/muzei/examplesource500px/FiveHundredPxExampleArtSource.java
@@ -66,7 +66,7 @@ public class FiveHundredPxExampleArtSource extends RemoteMuzeiArtSource {
                     @Override
                     public Throwable handleError(RetrofitError retrofitError) {
                         int statusCode = retrofitError.getResponse().getStatus();
-                        if (retrofitError.isNetworkError()
+                        if (retrofitError.getKind() == RetrofitError.Kind.NETWORK
                                 || (500 <= statusCode && statusCode < 600)) {
                             return new RetryException();
                         }


### PR DESCRIPTION
In #65, we moved from setServer() to setEndpoint(). However, that method does not exist in the Retrofit 1.3.0 we were using. Update to Retrofit 1.7.1 to gain access to the setEndpoint() method. Also fixes the deprecation of isNetworkError().
