### PR TITLE
Update all dependencies to latest stable versions

### DIFF
--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.1'
+        classpath 'com.android.tools.build:gradle:0.14.4'
     }
 }
 
@@ -30,14 +30,14 @@ repositories {
 }
 
 dependencies {
-    compile 'com.squareup.retrofit:retrofit:1.7.1'
+    compile 'com.squareup.retrofit:retrofit:1.8.0'
     //compile 'com.google.android.apps.muzei:muzei-api:+'
     compile project(':api')
 }
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1"
+    buildToolsVersion "21.1.1"
 
     defaultConfig {
         minSdkVersion 17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 03 19:11:35 PST 2014
+#Wed Nov 26 14:31:42 PST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.1'
+        classpath 'com.android.tools.build:gradle:0.14.4'
     }
 }
 
@@ -32,15 +32,13 @@ repositories {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:1.2.1'
-    compile 'com.squareup.picasso:picasso:2.1.1'
+    compile 'com.squareup.okhttp:okhttp:2.1.0'
+    compile 'com.squareup.okhttp:okhttp-urlconnection:2.1.0'
+    compile 'com.squareup.picasso:picasso:2.4.0'
     compile 'com.google.android.gms:play-services:6.1.71'
-    compile ('de.greenrobot:eventbus:2.2.0') {
-        exclude group:'com.google.android', module: 'support-v4' // already included below
-    }
-    compile 'com.android.support:support-v4:21.0.0'
-    compile 'com.android.support:appcompat-v7:21.+'
-    compile 'com.android.support:recyclerview-v7:21.+'
+    compile 'de.greenrobot:eventbus:2.4.0'
+    compile 'com.android.support:appcompat-v7:21.0.2'
+    compile 'com.android.support:recyclerview-v7:21.0.2'
 
     // :api is included as a transitive dependency from :provider
     // compile project(':api')
@@ -50,7 +48,7 @@ dependencies {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1"
+    buildToolsVersion "21.1.1"
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))

--- a/main/src/main/java/com/google/android/apps/muzei/util/IOUtil.java
+++ b/main/src/main/java/com/google/android/apps/muzei/util/IOUtil.java
@@ -25,6 +25,7 @@ import android.support.v4.os.EnvironmentCompat;
 import android.text.TextUtils;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.OkUrlFactory;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -103,7 +104,7 @@ public class IOUtil {
             int responseCode = 0;
             String responseMessage = null;
             try {
-                conn = client.open(new URL(uri.toString()));
+                conn = new OkUrlFactory(client).open(new URL(uri.toString()));
                 conn.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
                 conn.setReadTimeout(DEFAULT_READ_TIMEOUT);
                 responseCode = conn.getResponseCode();
@@ -270,7 +271,7 @@ public class IOUtil {
 
         try {
             OkHttpClient client = new OkHttpClient();
-            HttpURLConnection conn = client.open(url);
+            HttpURLConnection conn = new OkUrlFactory(client).open(url);
             conn.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
             conn.setReadTimeout(DEFAULT_READ_TIMEOUT);
             in = conn.getInputStream();

--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -25,6 +25,10 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+dependencies {
+    compile project(':api')
+}
+
 android {
     compileSdkVersion 21
     buildToolsVersion "21.1.1"
@@ -33,8 +37,4 @@ android {
         minSdkVersion 4
         targetSdkVersion 21
     }
-}
-
-dependencies {
-    compile project(':api')
 }

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -25,6 +25,13 @@ buildscript {
 
 apply plugin: 'com.android.application'
 
+dependencies {
+    compile 'com.google.android.support:wearable:1.0.0'
+    compile 'com.google.android.gms:play-services-wearable:6.1.71'
+    compile project(':provider')
+}
+
+
 android {
     compileSdkVersion 21
     buildToolsVersion "21.1.1"
@@ -77,10 +84,4 @@ android {
             versionNameSuffix " Debug " + versionProps['betaNumber']
         }
     }
-}
-
-dependencies {
-    compile 'com.google.android.support:wearable:1.0.0'
-    compile 'com.google.android.gms:play-services-wearable:6.1.71'
-    compile project(':provider')
 }


### PR DESCRIPTION
All:
- Gradle version: 2.1 to 2.2.1 (required for Android Studio 1.0 RC2)
- Gradle plugin: 0.14.1 to 0.14.4
- Build tools: 21.1 to 21.1.1

Main:
- okhttp:1.2.1 to okhttp:2.1.0 and okhttp-urlconnection:2.1.0
- picasso:2.1.1 to picasso:2.4.0
- eventbus:2.2.0 to eventbus:2.4.0
- support-v4:21.0.0 is transitively added via appcompat, removed from build.gradle
- appcompat-v7:21.+ to appcompat-v7:21.0.2
- recyclerview-v7:21.+ to recyclerview-v7:21.0.2

example-source-500px:
- retrofit:1.7.1 to retrofit:1.8.0

provider:
- Reordering build.gradle to match others

wearable:
- Reordering build.gradle to match others
