### PR TITLE
Handle Invalid Images without crashing

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/ArtworkCache.java
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtworkCache.java
@@ -30,10 +30,12 @@ import com.google.android.apps.muzei.api.Artwork;
 import com.google.android.apps.muzei.api.internal.SourceState;
 import com.google.android.apps.muzei.event.ArtworkLoadingStateChangedEvent;
 import com.google.android.apps.muzei.event.CurrentArtworkDownloadedEvent;
+import com.google.android.apps.muzei.render.BitmapRegionLoader;
 import com.google.android.apps.muzei.util.IOUtil;
 import com.google.android.apps.muzei.util.LogUtil;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
@@ -124,8 +126,10 @@ public class ArtworkCache {
             if (!tempFile.renameTo(destFile)) {
                 throw new IOException("Couldn't move temp artwork file to final cache location.");
             }
+            // Attempt to parse the newly downloaded file as an image, ensuring it is in a valid format
+            BitmapRegionLoader.newInstance(new FileInputStream(destFile));
         } catch (IOException e) {
-            LOGE(TAG, "Error loading and caching current artwork.", e);
+            LOGE(TAG, "Error caching and loading the current artwork. URI: " + currentArtwork.getImageUri(), e);
             destFile.delete();
             EventBus.getDefault().postSticky(new ArtworkLoadingStateChangedEvent(false, true));
             scheduleRetryArtworkDownload();

--- a/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
@@ -21,19 +21,15 @@ import android.graphics.BitmapRegionDecoder;
 import android.graphics.Matrix;
 import android.graphics.Rect;
 
-import com.google.android.apps.muzei.util.LogUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
 
 import static android.graphics.BitmapFactory.Options;
-import static com.google.android.apps.muzei.util.LogUtil.LOGE;
 
 /**
  * Wrapper for {@link BitmapRegionDecoder} with some extra functionality.
  */
 public class BitmapRegionLoader {
-    private static final String TAG = LogUtil.makeLogTag(BitmapRegionLoader.class);
     private boolean mValid = false;
     private int mRotation = 0;
     private int mOriginalWidth;
@@ -43,11 +39,11 @@ public class BitmapRegionLoader {
     private volatile BitmapRegionDecoder mBitmapRegionDecoder;
     private Matrix mRotateMatrix;
 
-    public static BitmapRegionLoader newInstance(InputStream in) {
+    public static BitmapRegionLoader newInstance(InputStream in) throws IOException {
         return newInstance(in, 0);
     }
 
-    public static BitmapRegionLoader newInstance(InputStream in, int rotation) {
+    public static BitmapRegionLoader newInstance(InputStream in, int rotation) throws IOException {
         if (in == null) {
             return null;
         }
@@ -65,15 +61,13 @@ public class BitmapRegionLoader {
         return null;
     }
 
-    private BitmapRegionLoader(InputStream in) {
+    private BitmapRegionLoader(InputStream in) throws IOException {
         mInputStream = in;
-        try {
-            mBitmapRegionDecoder = BitmapRegionDecoder.newInstance(in, false);
+        mBitmapRegionDecoder = BitmapRegionDecoder.newInstance(in, false);
+        if (mBitmapRegionDecoder != null) {
             mOriginalWidth = mBitmapRegionDecoder.getWidth();
             mOriginalHeight = mBitmapRegionDecoder.getHeight();
             mValid = true;
-        } catch (IOException e) {
-            LOGE(TAG, "Couldn't create bitmap loader.", e);
         }
     }
 

--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -112,6 +112,9 @@ public class RealRenderController extends RenderController {
         } catch (FileNotFoundException e) {
             LOGE(TAG, "Couldn't load artwork: " + file.getAbsolutePath(), e);
             return null;
+        } catch (IOException e) {
+            LOGE(TAG, "Error loading image: " + file.getAbsolutePath() + " from " + currentArtwork.getImageUri(), e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
Previously, Muzei assumed that if a file specified by an art source was downloaded that it was a valid image, leading to crashes when loading the BitmapRegionLoader on an invalid file. This fix attempts to open the image immediately after writing it to ensure that the image is valid and able to be parsed by Muzei. By doing this at the ArtworkCache level, we can properly mark the error state and show grumpy mcpuzzles for invalid images.
