### PR TITLE
Use Renderscript Support Library

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -36,5 +36,7 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 21
+        renderscriptTargetApi 21
+        renderscriptSupportModeEnabled true
     }
 }

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
@@ -18,13 +18,13 @@ package com.google.android.apps.muzei.util;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.renderscript.Allocation;
-import android.renderscript.Element;
-import android.renderscript.Matrix3f;
-import android.renderscript.RSInvalidStateException;
-import android.renderscript.RenderScript;
-import android.renderscript.ScriptIntrinsicBlur;
-import android.renderscript.ScriptIntrinsicColorMatrix;
+import android.support.v8.renderscript.Allocation;
+import android.support.v8.renderscript.Element;
+import android.support.v8.renderscript.Matrix3f;
+import android.support.v8.renderscript.RSInvalidStateException;
+import android.support.v8.renderscript.RenderScript;
+import android.support.v8.renderscript.ScriptIntrinsicBlur;
+import android.support.v8.renderscript.ScriptIntrinsicColorMatrix;
 
 public class ImageBlurrer {
     public static final int MAX_SUPPORTED_BLUR_PIXELS = 25;
@@ -38,7 +38,6 @@ public class ImageBlurrer {
     public ImageBlurrer(Context context) {
         mRS = RenderScript.create(context);
         mSIBlur = ScriptIntrinsicBlur.create(mRS, Element.U8_4(mRS));
-        // NOTE: ScriptIntrinsicColorMatrix.create(RenderScript) only supports API19+
         mSIGrey = ScriptIntrinsicColorMatrix.create(mRS, Element.U8_4(mRS));
     }
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -41,6 +41,8 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 21
+        renderscriptTargetApi 21
+        renderscriptSupportModeEnabled true
 
         versionName versionProps['name']
         versionCode versionProps['code'].toInteger()
@@ -93,6 +95,7 @@ android {
         publicDebug.initWith(buildTypes.publicBeta)
         publicDebug {
             debuggable true
+            renderscriptDebuggable true
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), file('proguard-project.txt')

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -37,6 +37,8 @@ android {
     defaultConfig {
         minSdkVersion 20
         targetSdkVersion 21
+        renderscriptTargetApi 21
+        renderscriptSupportModeEnabled true
 
         versionName versionProps['name']
         versionCode versionProps['code'].toInteger()


### PR DESCRIPTION
Instead of relying on possibly buggy native Renderscript implementations, use the Support Library version which is consistent across all devices/API versions.
