### PR TITLE
Remove Wearable.API warning messages when API is unavailable

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/WearableController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/WearableController.java
@@ -56,7 +56,7 @@ public class WearableController {
                 .build();
         ConnectionResult connectionResult = googleApiClient.blockingConnect(30, TimeUnit.SECONDS);
         if (!connectionResult.isSuccess()) {
-            if (connectionResult.getErrorCode() != ConnectionResult.API_UNAVAILABLE) {
+            if (connectionResult.getErrorCode() == ConnectionResult.API_UNAVAILABLE) {
                 LOGV(TAG, "Wearable API unavailable, cancelling updateDataLayer request");
             } else {
                 LOGW(TAG, "onConnectionFailed: " + connectionResult);


### PR DESCRIPTION
When `connectionResult.getErrorCode() == ConnectionResult.API_UNAVAILABLE`, this means we are on an unsupported device and we should not attempt to update the data layer. However, since that status is unlikely to change over the course of the app's lifecycle, creating a warning message each and every time this happens is unnecessary. Instead, we can do a simple verbose statement that does not spam logcat unless specifically requested.
