### PR TITLE
Improve Watch Face first run experience

### DIFF
--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -48,6 +48,8 @@
             </intent-filter>
         </service>
 
+        <service android:name="com.google.android.apps.muzei.ArtworkCacheIntentService" />
+
         <service
             android:name="com.google.android.apps.muzei.MuzeiWatchFace"
             android:allowEmbedded="true"

--- a/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.preference.PreferenceManager;
 import android.support.wearable.activity.ConfirmationActivity;
 import android.text.TextUtils;
@@ -36,6 +37,7 @@ import com.google.android.gms.wearable.Wearable;
 
 import net.nurik.roman.muzei.R;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +48,7 @@ public class ActivateMuzeiIntentService extends IntentService {
     private static final String ACTION_MARK_NOTIFICATION_READ =
             "com.google.android.apps.muzei.action.NOTIFICATION_DELETED";
 
-    public static void maybeShowActivateMuzeiNotification(Context context, Bitmap background) {
+    public static void maybeShowActivateMuzeiNotification(Context context) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         if (preferences.getBoolean(ACTIVATE_MUZEI_NOTIF_SHOWN_PREF_KEY, false)) {
             return;
@@ -67,6 +69,12 @@ public class ActivateMuzeiIntentService extends IntentService {
                 .extend(new Notification.Action.WearableExtender()
                         .setAvailableOffline(false))
                 .build());
+        Bitmap background = null;
+        try {
+            background = BitmapFactory.decodeStream(context.getAssets().open("starrynight.jpg"));
+        } catch (IOException e) {
+            Log.e(TAG, "Error reading default background asset", e);
+        }
         builder.extend(new Notification.WearableExtender()
                 .setContentAction(0)
                 .setBackground(background));

--- a/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei;
+
+import android.app.IntentService;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import com.google.android.apps.muzei.api.Artwork;
+import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.android.apps.muzei.provider.MuzeiProvider;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.wearable.Asset;
+import com.google.android.gms.wearable.DataApi;
+import com.google.android.gms.wearable.DataItem;
+import com.google.android.gms.wearable.DataItemBuffer;
+import com.google.android.gms.wearable.DataMap;
+import com.google.android.gms.wearable.DataMapItem;
+import com.google.android.gms.wearable.Wearable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * IntentService responsible to for retrieving the artwork from the DataLayer and caching it locally
+ * to make it available via the Artwork API.
+ *
+ * <p>Optionally pass {@link #SHOW_ACTIVATE_NOTIFICATION_EXTRA} with your Intent to show a
+ * notification to activate Muzei if the artwork is not found
+ */
+public class ArtworkCacheIntentService extends IntentService {
+    private static final String TAG = ArtworkCacheIntentService.class.getSimpleName();
+    public static final String SHOW_ACTIVATE_NOTIFICATION_EXTRA = "SHOW_ACTIVATE_NOTIFICATION";
+
+    public ArtworkCacheIntentService() {
+        super(TAG);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        GoogleApiClient googleApiClient = new GoogleApiClient.Builder(this)
+                .addApi(Wearable.API)
+                .build();
+        ConnectionResult connectionResult =
+                googleApiClient.blockingConnect(30, TimeUnit.SECONDS);
+        if (!connectionResult.isSuccess()) {
+            Log.e(TAG, "Failed to connect to GoogleApiClient: " + connectionResult.getErrorCode());
+            return;
+        }
+        // Read all DataItems
+        DataItemBuffer dataItemBuffer = Wearable.DataApi.getDataItems(googleApiClient).await();
+        if (!dataItemBuffer.getStatus().isSuccess()) {
+            Log.e(TAG, "Error getting all data items: " + dataItemBuffer.getStatus().getStatusMessage());
+        }
+        Iterator<DataItem> dataItemIterator = dataItemBuffer.singleRefIterator();
+        boolean foundArtwork = false;
+        while (dataItemIterator.hasNext()) {
+            DataItem dataItem = dataItemIterator.next();
+            foundArtwork = foundArtwork || processDataItem(googleApiClient, dataItem);
+        }
+        dataItemBuffer.close();
+        if (!foundArtwork && intent != null &&
+                intent.getBooleanExtra(SHOW_ACTIVATE_NOTIFICATION_EXTRA, false)) {
+            ActivateMuzeiIntentService.maybeShowActivateMuzeiNotification(this);
+        }
+        googleApiClient.disconnect();
+    }
+
+
+    private boolean processDataItem(GoogleApiClient googleApiClient, DataItem dataItem) {
+        if (!dataItem.getUri().getPath().equals("/artwork")) {
+            Log.w(TAG, "Ignoring data item " + dataItem.getUri().getPath());
+            return false;
+        }
+        DataMapItem dataMapItem = DataMapItem.fromDataItem(dataItem);
+        DataMap artworkDataMap = dataMapItem.getDataMap().getDataMap("artwork");
+        if (artworkDataMap == null) {
+            Log.w(TAG, "No artwork in datamap.");
+            return false;
+        }
+        final Artwork artwork = Artwork.fromBundle(artworkDataMap.toBundle());
+        final Asset asset = dataMapItem.getDataMap().getAsset("image");
+        if (asset == null) {
+            Log.w(TAG, "No image asset in datamap.");
+            return false;
+        }
+        // Convert asset into a file descriptor and block until it's ready
+        final DataApi.GetFdForAssetResult getFdForAssetResult =
+                Wearable.DataApi.getFdForAsset(googleApiClient, asset).await();
+        InputStream assetInputStream = getFdForAssetResult.getInputStream();
+        if (assetInputStream == null) {
+            Log.w(TAG, "Empty asset input stream (probably an unknown asset).");
+            return false;
+        }
+        Bitmap image = BitmapFactory.decodeStream(assetInputStream);
+        if (image == null) {
+            Log.w(TAG, "Couldn't decode a bitmap from the stream.");
+            return false;
+        }
+        File localCache = new File(getCacheDir(), "cache.png");
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(localCache);
+            image.compress(Bitmap.CompressFormat.PNG, 100, out);
+        } catch (IOException e) {
+            Log.e(TAG, "Error writing local cache", e);
+        } finally {
+            try {
+                if (out != null) {
+                    out.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "Error closing local cache file", e);
+            }
+        }
+        enableComponents(FullScreenActivity.class);
+        if (MuzeiProvider.saveCurrentArtworkLocation(this, localCache)) {
+            getContentResolver().insert(MuzeiContract.Artwork.CONTENT_URI, artwork.toContentValues());
+        }
+        return true;
+    }
+
+    private void enableComponents(Class<?>... components) {
+        PackageManager packageManager = getPackageManager();
+        for (Class<?> component : components) {
+            ComponentName componentName = new ComponentName(this, component);
+            packageManager.setComponentEnabledSetting(componentName,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP);
+        }
+    }
+}

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -97,8 +97,11 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
                 if (bitmap == null) {
                     try {
                         bitmap = BitmapFactory.decodeStream(getAssets().open("starrynight.jpg"));
-                        ActivateMuzeiIntentService.maybeShowActivateMuzeiNotification(
-                                MuzeiWatchFace.this, bitmap);
+                        // Try to download the artwork from the DataLayer, showing a notification
+                        // to activate Muzei if it isn't found
+                        Intent intent = new Intent(MuzeiWatchFace.this, ArtworkCacheIntentService.class);
+                        intent.putExtra(ArtworkCacheIntentService.SHOW_ACTIVATE_NOTIFICATION_EXTRA, true);
+                        startService(intent);
                     } catch (IOException e) {
                         Log.e(TAG, "Error opening starry night asset", e);
                     }

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWearableListenerService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWearableListenerService.java
@@ -16,123 +16,26 @@
 
 package com.google.android.apps.muzei;
 
-import android.content.ComponentName;
-import android.content.pm.PackageManager;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.os.Binder;
-import android.util.Log;
+import android.content.Intent;
 
-import com.google.android.apps.muzei.api.Artwork;
-import com.google.android.apps.muzei.api.MuzeiContract;
-import com.google.android.apps.muzei.provider.MuzeiProvider;
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.wearable.Asset;
-import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
-import com.google.android.gms.wearable.DataItem;
-import com.google.android.gms.wearable.DataMap;
-import com.google.android.gms.wearable.DataMapItem;
-import com.google.android.gms.wearable.Wearable;
 import com.google.android.gms.wearable.WearableListenerService;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
 
 /**
  * WearableListenerService responsible to receiving Data Layer changes with updated artwork
  */
 public class MuzeiWearableListenerService extends WearableListenerService {
-    private static final String TAG = MuzeiWearableListenerService.class.getSimpleName();
-
     @Override
     public void onDataChanged(final DataEventBuffer dataEvents) {
-        long token = Binder.clearCallingIdentity();
-        try {
-            for (DataEvent dataEvent : dataEvents) {
-                if (dataEvent.getType() != DataEvent.TYPE_CHANGED) {
-                    continue;
-                }
-                processDataItem(dataEvent.getDataItem());
+        for (DataEvent dataEvent : dataEvents) {
+            if (dataEvent.getType() != DataEvent.TYPE_CHANGED) {
+                continue;
             }
-        } finally {
-            Binder.restoreCallingIdentity(token);
-        }
-    }
-
-    private void processDataItem(DataItem dataItem) {
-        if (!dataItem.getUri().getPath().equals("/artwork")) {
-            Log.w(TAG, "Ignoring data item " + dataItem.getUri().getPath());
-            return;
-        }
-        DataMapItem dataMapItem = DataMapItem.fromDataItem(dataItem);
-        DataMap artworkDataMap = dataMapItem.getDataMap().getDataMap("artwork");
-        if (artworkDataMap == null) {
-            Log.w(TAG, "No artwork in datamap.");
-            return;
-        }
-        final Artwork artwork = Artwork.fromBundle(artworkDataMap.toBundle());
-        final Asset asset = dataMapItem.getDataMap().getAsset("image");
-        if (asset == null) {
-            Log.w(TAG, "No image asset in datamap.");
-            return;
-        }
-        GoogleApiClient googleApiClient = new GoogleApiClient.Builder(this)
-                .addApi(Wearable.API)
-                .build();
-        ConnectionResult connectionResult =
-                googleApiClient.blockingConnect(30, TimeUnit.SECONDS);
-        if (!connectionResult.isSuccess()) {
-            Log.e(TAG, "Failed to connect to GoogleApiClient.");
-            return;
-        }
-        // Convert asset into a file descriptor and block until it's ready
-        final DataApi.GetFdForAssetResult getFdForAssetResult =
-                Wearable.DataApi.getFdForAsset(googleApiClient, asset).await();
-        InputStream assetInputStream = getFdForAssetResult.getInputStream();
-        if (assetInputStream == null) {
-            Log.w(TAG, "Empty asset input stream (probably an unknown asset).");
-            return;
-        }
-        Bitmap image = BitmapFactory.decodeStream(assetInputStream);
-        if (image == null) {
-            Log.w(TAG, "Couldn't decode a bitmap from the stream.");
-            return;
-        }
-        File localCache = new File(getCacheDir(), "cache.png");
-        FileOutputStream out = null;
-        try {
-            out = new FileOutputStream(localCache);
-            image.compress(Bitmap.CompressFormat.PNG, 100, out);
-        } catch (IOException e) {
-            Log.e(TAG, "Error writing local cache", e);
-        } finally {
-            try {
-                if (out != null) {
-                    out.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing local cache file", e);
+            if (dataEvent.getDataItem().getUri().getPath().equals("/artwork")) {
+                // Kick off a service responsible for reloading the current artwork
+                startService(new Intent(this, ArtworkCacheIntentService.class));
             }
-        }
-        enableComponents(FullScreenActivity.class);
-        if (MuzeiProvider.saveCurrentArtworkLocation(MuzeiWearableListenerService.this, localCache)) {
-            getContentResolver().insert(MuzeiContract.Artwork.CONTENT_URI, artwork.toContentValues());
-        }
-    }
-
-    private void enableComponents(Class<?>... components) {
-        PackageManager packageManager = getPackageManager();
-        for (Class<?> component : components) {
-            ComponentName componentName = new ComponentName(this, component);
-            packageManager.setComponentEnabledSetting(componentName,
-                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                    PackageManager.DONT_KILL_APP);
         }
     }
 }


### PR DESCRIPTION
In the case where the user has just updated to Muzei 2.0+ (i.e., went from no Wearable app to a Wearable app) AND has not yet had their wallpaper change, there may be cases where the DataLayer has valid artwork, but it is not yet cached locally or made available via the Artwork API.

In those cases, the Muzei watch face would show a notification stating that the user should activate Muzei when no artwork is found. Instead, we should attempt to retrieve the artwork from the DataLayer first and only if that fails should we show the activate Muzei notification.

Note: this moves a lot of code from MuzeiWearableListenerService to ArtworkCacheIntentService, but the functionality is identical.
