### PR TITLE
Update AppCompat from 21.0.2 to 21.0.3

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.4.0'
     compile 'com.google.android.gms:play-services-wearable:6.5.87'
     compile 'de.greenrobot:eventbus:2.4.0'
-    compile 'com.android.support:appcompat-v7:21.0.2'
+    compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:recyclerview-v7:21.0.2'
 
     // :api is included as a transitive dependency from :android-client-common


### PR DESCRIPTION
Update to `com.android.support:appcompat-v7:21.0.3` to ensure we have the latest bug fixes
