### PR TITLE
BackupAgent for advanced settings.

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -35,11 +35,16 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:backupAgent="com.google.android.apps.muzei.settings.SettingsBackupAgent">
 
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
+
+        <meta-data
+            android:name="com.google.android.backup.api_key"
+            android:value="REPLACE_ME" />
 
         <activity
             android:name="com.google.android.apps.muzei.MuzeiActivity"

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsBackupAgent.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsBackupAgent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.apps.muzei.settings;
+
+import android.app.backup.BackupAgentHelper;
+import android.app.backup.SharedPreferencesBackupHelper;
+
+public class SettingsBackupAgent extends BackupAgentHelper {
+    static final String PREFS_ADVANCED_BACKUP = "advanced_prefs";
+
+    public void onCreate() {
+        String preferencesName = getPreferencesName();
+
+        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this, preferencesName);
+        addHelper(PREFS_ADVANCED_BACKUP, helper);
+    }
+
+    private String getPreferencesName() {
+        return String.format("%s_preferences", getPackageName());
+    }
+}


### PR DESCRIPTION
I would still consider this a work in progress. I've opened this pull request mostly for a discussion around the changes I've made.

This BackupAgent will backup the advanced settings stored in the default
SharedPreferences. Backing up the default preferences is a bit hacky
since the name isn't easily accessible. Ideally, this would be moved
over to a named SharedPreferences so future OS updates don't break the
backing naming.

Also, need a proper way to handle the backup api key so it isn't stored
in the source code.

This is in reference to #110 @romannurik any thoughts on the way it uses the default preferences? Should I create named preferences and provide an upgrade path? 
