### PR TITLE
Move Gradle, build tools, and compile/target SDK to main build.gradle

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 17

--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
@@ -30,13 +30,13 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 21
-        renderscriptTargetApi 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        renderscriptTargetApi rootProject.ext.targetSdkVersion
         renderscriptSupportModeEnabled true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,22 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ext {
+    gradleClasspath = 'com.android.tools.build:gradle:1.0.1'
+    compileSdkVersion = 21
+    buildToolsVersion = "21.1.2"
+    targetSdkVersion = compileSdkVersion
+}

--- a/example-contract-widget/build.gradle
+++ b/example-contract-widget/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
@@ -35,11 +35,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 }

--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
@@ -36,11 +36,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 }

--- a/example-watchface/build.gradle
+++ b/example-watchface/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
@@ -33,11 +33,11 @@ dependencies {
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
@@ -32,16 +32,16 @@ repositories {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 21
-        renderscriptTargetApi 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        renderscriptTargetApi rootProject.ext.targetSdkVersion
         renderscriptSupportModeEnabled true
 
         versionName versionProps['name']

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -19,15 +19,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath rootProject.ext.gradleClasspath
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('version.properties')))
@@ -36,8 +36,8 @@ android {
 
     defaultConfig {
         minSdkVersion 20
-        targetSdkVersion 21
-        renderscriptTargetApi 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        renderscriptTargetApi rootProject.ext.targetSdkVersion
         renderscriptSupportModeEnabled true
 
         versionName versionProps['name']

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 application: muzeiapi
-version: 8
+version: 9
 runtime: python27
 api_version: 1
 threadsafe: false

--- a/web/handlers/tasks.py
+++ b/web/handlers/tasks.py
@@ -148,8 +148,7 @@ class UpdateArchiveTaskHandler(BaseHandler):
         archive_name = '%04d%02d' % archive
         next_month = datetime.date(archive[0], archive[1], 1)
         if next_month.month == 12:
-          next_month = next_month.replace(year=next_month.year + 1)
-          next_month.month = 1
+          next_month = next_month.replace(year=next_month.year + 1, month=1)
         else:
           next_month = next_month.replace(month=next_month.month + 1)
         query_to = next_month - datetime.timedelta(days=1)

--- a/web/static/archive/archive.js
+++ b/web/static/archive/archive.js
@@ -315,7 +315,7 @@ function renderMonthContents(month) {
         // previous month
         skipDay = true;
         classes += 'skipped ';
-        if (dayMonth < month[1] - 1) {
+        if ((dayMonth < month[1] - 1) || (month[1] == 1 && dayMonth == 11)) {
           classes += 'before ';
         } else {
           break;


### PR DESCRIPTION
In order to not touch every build.gradle file every time either the gradle plugin updates or the build tools updates or the newest SDK comes out, we can move all of these values to the main build.gradle file as suggested here: http://tools.android.com/tech-docs/new-build-system/tips

This update also updates the gradle plugin 1.0.0 to 1.0.1 and build tools 21.1.1 to 21.1.2