### PR TITLE
Version cleanup

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -28,7 +28,7 @@ props.load(new FileInputStream(file('../local.properties')))
 
 def android = [
         sdk: props["sdk.dir"],
-        target: 'android-21'
+        target: 'android-22'
 ]
 
 allprojects { ext."signing.keyId" = props["signing.keyId"] }

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -37,10 +37,6 @@
         android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true">
 
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
-
         <activity
             android:name="com.google.android.apps.muzei.MuzeiActivity"
             android:theme="@style/Theme.MuzeiActivity"

--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -27,9 +27,6 @@
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version"/>
 
         <activity
             android:name="com.google.android.apps.muzei.FullScreenActivity"


### PR DESCRIPTION
Update Muzei API to build against API 22 and removes no longer needed <meta-data> elements as they are included by default by Google Play services 7.0