### PR TITLE
Remove double call to super.onPeekCardPositionUpdate() from watch face

### DIFF
--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -423,7 +423,6 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
 
         @Override
         public void onPeekCardPositionUpdate(Rect bounds) {
-            super.onPeekCardPositionUpdate(bounds);
             if (Log.isLoggable(TAG, Log.DEBUG)) {
                 Log.d(TAG, "onPeekCardPositionUpdate: " + bounds);
             }


### PR DESCRIPTION
Don't want to call the super method twice.