### PR TITLE
implement support for ActionLauncher 3's theming API

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:recyclerview-v7:21.0.2'
-
+    compile 'com.actionlauncher:action3-api:1.+'
     // :api is included as a transitive dependency from :android-client-common
     // compile project(':api')
     compile project(':android-client-common')

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -148,5 +148,12 @@
             </intent-filter>
         </service>
 
+        <service android:name="com.actionlauncher.api.LiveWallpaperSource"
+            android:label="LiveWallpaperSource"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.actionlauncher.api.action.LiveWallpaperSource" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>


### PR DESCRIPTION
As there is such a nice integration between the form watch face and muzei I thought it might be cool to have the same kind of integration into aciton launcher. As the code is really simple I guess that would be a nice addition :)

I took the blurred version of the image as a base to match the color in the launcher as good as possible. If this is not a good idea it can easily be changed by moving the code piece around to the correct place.

What do you think?