### PR TITLE
Use the CapabilityApi to send activate messages to the correct node

### DIFF
--- a/main/src/main/res/values/wear.xml
+++ b/main/src/main/res/values/wear.xml
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2014 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<resources>
+    <string-array name="android_wear_capabilities">
+        <item>activate_muzei</item>
+    </string-array>
+</resources>

--- a/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
@@ -32,13 +32,14 @@ import android.util.Log;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.wearable.CapabilityApi;
 import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.Wearable;
 
 import net.nurik.roman.muzei.R;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class ActivateMuzeiIntentService extends IntentService {
@@ -108,7 +109,9 @@ public class ActivateMuzeiIntentService extends IntentService {
             Log.e(TAG, "Failed to connect to GoogleApiClient.");
             return;
         }
-        List<Node> nodes =  Wearable.NodeApi.getConnectedNodes(googleApiClient).await().getNodes();
+        Set<Node> nodes =  Wearable.CapabilityApi.getCapability(googleApiClient, "activate_muzei",
+                CapabilityApi.FILTER_REACHABLE).await()
+                .getCapability().getNodes();
         if (!nodes.isEmpty()) {
             // Show the open on phone animation
             Intent openOnPhoneIntent = new Intent(this, ConfirmationActivity.class);


### PR DESCRIPTION
Replaces the Wearable.NodeApi.getConnectedNodes() call with a call to Wearable.CapabilityApi.getCapability(), ensuring that only the main app (which has the capability 'activate_muzei') will receive the message to activate Muzei, rather than other Wearable devices or the cloud node.