### PR TITLE
Implement simple blur toggle interactive watch face

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
@@ -46,7 +46,7 @@ public class ImageBlurrer {
             return null;
         }
 
-        Bitmap dest = Bitmap.createBitmap(src);
+        Bitmap dest = src.copy(src.getConfig(), false);
         if (radius == 0f && desaturateAmount == 0f) {
             return dest;
         }

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -88,7 +88,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.1.0'
+    compile 'com.google.android.support:wearable:1.3.0'
     compile 'com.google.android.gms:play-services-wearable:7.5.0'
     compile project(':android-client-common')
 }


### PR DESCRIPTION
Allow tapping on the watchface to toggle between the image and a blurred/dimmed version of the image.

Also updates:
- peek card opacity (transparent when blurred, opaque when not blurred)
- Only use view protection when not blurred
- Shadow behind time/date only shown when not blurred