### PR TITLE
When adding multiple pictures, use both getData and getClipData. Some…

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -528,7 +528,7 @@ public class GallerySettingsActivity extends ActionBarActivity {
         }
 
         // Add chosen items
-        ArrayList<Uri> uris = new ArrayList<>();
+        Set<Uri> uris = new HashSet<>();
         if (result.getData() != null) {
             uris.add(result.getData());
         }
@@ -545,7 +545,7 @@ public class GallerySettingsActivity extends ActionBarActivity {
         // Update chosen URIs
         startService(new Intent(GallerySettingsActivity.this, GalleryArtSource.class)
                 .setAction(ACTION_ADD_CHOSEN_URIS)
-                .putParcelableArrayListExtra(EXTRA_URIS, uris));
+                .putParcelableArrayListExtra(EXTRA_URIS, new ArrayList<>(uris)));
     }
 
     public void onEventMainThread(GalleryChosenUrisChangedEvent e) {

--- a/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -531,13 +531,14 @@ public class GallerySettingsActivity extends ActionBarActivity {
         ArrayList<Uri> uris = new ArrayList<>();
         if (result.getData() != null) {
             uris.add(result.getData());
-        } else {
-            ClipData clipData = result.getClipData();
-            if (clipData != null) {
-                int count = clipData.getItemCount();
-                for (int i = 0; i < count; i++) {
-                    uris.add(clipData.getItemAt(i).getUri());
-                }
+        }
+        // When selecting multiple images, "Photos" returns the first URI in getData and all URIs
+        // in getClipData.
+        ClipData clipData = result.getClipData();
+        if (clipData != null) {
+            int count = clipData.getItemCount();
+            for (int i = 0; i < count; i++) {
+                uris.add(clipData.getItemAt(i).getUri());
             }
         }
 


### PR DESCRIPTION
… ContentProviders (e.g. Google Photos) use both and reading only getData ignores multiple images. This is extra annoying when the pictures are downloaded first.