### PR TITLE
Ensure Android Wear wallpaper updates immediately.

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/WearableController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/WearableController.java
@@ -83,7 +83,7 @@ public class WearableController {
             PutDataMapRequest dataMapRequest = PutDataMapRequest.create("/artwork");
             dataMapRequest.getDataMap().putDataMap("artwork", DataMap.fromBundle(artwork.toBundle()));
             dataMapRequest.getDataMap().putAsset("image", asset);
-            Wearable.DataApi.putDataItem(googleApiClient, dataMapRequest.asPutDataRequest()).await();
+            Wearable.DataApi.putDataItem(googleApiClient, dataMapRequest.asPutDataRequest().setUrgent()).await();
         }
         googleApiClient.disconnect();
     }


### PR DESCRIPTION
In Google Play services 8.3, DataApi calls may be delayed up to 30 minutes. Calling setUrgent() ensures the wallpaper is updated on the Android Wear side immediately upon being updated on the phone side (subject to connectivity, of course) as explained in the 8.3 blog post: http://android-developers.blogspot.com/2015/11/whats-new-in-google-play-services-83.html