### PR TITLE
Remove no longer needed PROVIDE_BACKGROUND permission for watch face

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -32,9 +32,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="22" />
 
-    <!-- Permissions required by the wearable app -->
-    <uses-permission android:name="com.google.android.permission.PROVIDE_BACKGROUND" />
-
     <application android:name="com.google.android.apps.muzei.MuzeiApplication"
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
     <uses-feature android:name="android.hardware.type.watch"/>
 
     <!-- Required to act as a custom watch face. -->
-    <uses-permission android:name="com.google.android.permission.PROVIDE_BACKGROUND" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
@@ -58,8 +57,6 @@
 
         <service
             android:name="com.google.android.apps.muzei.MuzeiWatchFace"
-            android:allowEmbedded="true"
-            android:taskAffinity=""
             android:permission="android.permission.BIND_WALLPAPER" >
             <meta-data
                 android:name="android.service.wallpaper"


### PR DESCRIPTION
Watch faces do not need the PROVIDE_BACKGROUND permission nor do they need android:allowEmbedded="true" and android:taskAffinity=""