### PR TITLE
Upgrade to Google Play services 9.2.1 to work around ProGuard issue

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -116,7 +116,7 @@ android {
 dependencies {
     compile "com.squareup.okhttp3:okhttp:3.3.1"
     compile "com.squareup.picasso:picasso:2.5.2"
-    compile "com.google.android.gms:play-services-wearable:9.2.0"
+    compile "com.google.android.gms:play-services-wearable:9.2.1"
     compile "org.greenrobot:eventbus:3.0.0"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"


### PR DESCRIPTION
Per https://developers.google.com/android/guides/releases#june_2016_-_v92