### PR TITLE
Limit Network Connectivity Callbacks

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
@@ -47,7 +47,8 @@ public class NetworkChangeReceiver extends WakefulBroadcastReceiver {
             // TODO: wakeful broadcast?
             Cursor selectedSources = context.getContentResolver().query(MuzeiContract.Sources.CONTENT_URI,
                     new String[]{MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME},
-                    MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED + "=1", null, null, null);
+                    MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED + "=1 AND " +
+                    MuzeiContract.Sources.COLUMN_NAME_WANTS_NETWORK_AVAILABLE + "=1", null, null, null);
             if (selectedSources != null && selectedSources.moveToPosition(-1)) {
                 while (selectedSources.moveToNext()) {
                     String componentName = selectedSources.getString(0);


### PR DESCRIPTION
Try to limit network connectivity callbacks to only apps that want network connectivity changes. Even then, don't send network change events to apps on API 24+ that target API 24+ as those apps should be following the behavior changes in API 24 which restrict network change events.