### PR TITLE
Tie subscribing and network changes to the wallpaper lifecyle

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -80,12 +80,6 @@
             android:theme="@style/Theme.Muzei.About"
             android:parentActivityName="com.google.android.apps.muzei.settings.SettingsActivity" />
 
-        <receiver android:name="com.google.android.apps.muzei.NetworkChangeReceiver">
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-            </intent-filter>
-        </receiver>
-
         <!-- Target for "Set As" intent -->
 
         <activity android:name="com.google.android.apps.muzei.PhotoSetAsTargetActivity"

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -50,11 +50,13 @@ public class MuzeiWallpaperService extends GLWallpaperService {
         super.onCreate();
         mLockScreenVisibleReceiver = new LockScreenVisibleReceiver();
         mLockScreenVisibleReceiver.setupRegisterDeregister(this);
+        SourceManager.getInstance(MuzeiWallpaperService.this).subscribeToSelectedSource();
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
+        SourceManager.getInstance(MuzeiWallpaperService.this).unsubscribeToSelectedSource();
         if (mLockScreenVisibleReceiver != null) {
             mLockScreenVisibleReceiver.destroy();
             mLockScreenVisibleReceiver = null;
@@ -93,7 +95,6 @@ public class MuzeiWallpaperService extends GLWallpaperService {
             mGestureDetector = new GestureDetector(MuzeiWallpaperService.this, mGestureListener);
             if (!isPreview()) {
                 EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(true));
-                SourceManager.getInstance(MuzeiWallpaperService.this).subscribeToSelectedSource();
             }
             setTouchEventsEnabled(true);
             setOffsetNotificationsEnabled(true);
@@ -114,7 +115,6 @@ public class MuzeiWallpaperService extends GLWallpaperService {
             super.onDestroy();
             EventBus.getDefault().unregister(this);
             if (!isPreview()) {
-                SourceManager.getInstance(MuzeiWallpaperService.this).unsubscribeToSelectedSource();
                 EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(false));
             }
             queueEvent(new Runnable() {

--- a/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
@@ -30,10 +30,6 @@ import static com.google.android.apps.muzei.api.internal.ProtocolConstants.ACTIO
 public class NetworkChangeReceiver extends WakefulBroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent == null || !ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
-            return;
-        }
-
         boolean hasConnectivity = !intent.getBooleanExtra(
                 ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
         if (hasConnectivity) {


### PR DESCRIPTION
Much of the activities that Muzei does should only be done when the wallpaper is active (i.e., the MuzeiWallpaperService is created). This fixes an issue where we wouldn't properly subscribe to sources when in preview mode and Muzei would continue to listen for network changes at all times (even when the wallpaper was disabled!). Now both events are done only when the wallpaper service is created.