### PR TITLE
Delete artwork being written when an error occurs.

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
@@ -471,6 +471,11 @@ public class MuzeiProvider extends ContentProvider {
                             if (isWriteOperation) {
                                 if (e != null) {
                                     Log.e(TAG, "Error closing " + file + " for " + uri, e);
+                                    if (file.exists()) {
+                                        if (!file.delete()) {
+                                            Log.w(TAG, "Unable to delete " + file);
+                                        }
+                                    }
                                 } else {
                                     // The file was successfully written, notify listeners of the new artwork
                                     notifyChange(uri);


### PR DESCRIPTION
Instead of keeping a possibly incomplete or a failed file for artwork being written to MuzeiProvider, if we detect an IOException on writing we'll try to delete the artwork file, allowing the other side to retry.