### PR TITLE
Reduce SourceManager contention when updating sources

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -265,15 +265,16 @@ public class SourceManager {
             } else {
                 mContentResolver.insert(MuzeiContract.Sources.CONTENT_URI, values);
             }
-            // We're already on a background thread, so it safe to call this directly
-            WearableController.updateSource(mApplicationContext);
             if (existingSource != null) {
                 existingSource.close();
             }
-
-            Artwork artwork = state.getCurrentArtwork();
-            mContentResolver.insert(MuzeiContract.Artwork.CONTENT_URI, artwork.toContentValues());
         }
+
+        // We're already on a background thread, so it safe to call this directly
+        WearableController.updateSource(mApplicationContext);
+
+        Artwork artwork = state.getCurrentArtwork();
+        mContentResolver.insert(MuzeiContract.Artwork.CONTENT_URI, artwork.toContentValues());
 
         // Download the artwork contained from the newly published SourceState
         mApplicationContext.startService(TaskQueueService.getDownloadCurrentArtworkIntent(mApplicationContext));


### PR DESCRIPTION
SourceManager uses synchronized to manage access to the selected source it maintains. By reducing the amount of code that needs to be in these synchronized blocks, we reduce contention and apparent freezes when changing sources.