### PR TITLE
Use MuzeiProvider as the source for all artwork updates

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
@@ -138,6 +138,18 @@ public class MuzeiProvider extends ContentProvider {
                 MuzeiContract.Artwork.COLUMN_NAME_VIEW_INTENT);
         allColumnProjectionMap.put(MuzeiContract.Artwork.COLUMN_NAME_META_FONT,
                 MuzeiContract.Artwork.COLUMN_NAME_META_FONT);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME,
+                MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED,
+                MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_DESCRIPTION,
+                MuzeiContract.Sources.COLUMN_NAME_DESCRIPTION);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_WANTS_NETWORK_AVAILABLE,
+                MuzeiContract.Sources.COLUMN_NAME_WANTS_NETWORK_AVAILABLE);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_SUPPORTS_NEXT_ARTWORK_COMMAND,
+                MuzeiContract.Sources.COLUMN_NAME_SUPPORTS_NEXT_ARTWORK_COMMAND);
+        allColumnProjectionMap.put(MuzeiContract.Sources.COLUMN_NAME_COMMANDS,
+                MuzeiContract.Sources.COLUMN_NAME_COMMANDS);
         return allColumnProjectionMap;
     }
 

--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -18,14 +18,10 @@ package com.google.android.apps.muzei.render;
 
 import android.content.Context;
 import android.database.ContentObserver;
-import android.database.Cursor;
 import android.net.Uri;
 import android.os.Handler;
-import android.provider.BaseColumns;
 import android.util.Log;
 
-import com.google.android.apps.muzei.NewWallpaperNotificationReceiver;
-import com.google.android.apps.muzei.wearable.WearableController;
 import com.google.android.apps.muzei.api.MuzeiContract;
 
 import java.io.IOException;
@@ -33,7 +29,6 @@ import java.io.IOException;
 public class RealRenderController extends RenderController {
     private static final String TAG = "RealRenderController";
 
-    private long mLastLoadedArtworkId = -1;
     private ContentObserver mContentObserver;
 
     public RealRenderController(Context context, MuzeiBlurRenderer renderer,
@@ -62,22 +57,8 @@ public class RealRenderController extends RenderController {
     protected BitmapRegionLoader openDownloadedCurrentArtwork(boolean forceReload) {
         // Load the stream
         try {
-            BitmapRegionLoader loader = BitmapRegionLoader.newInstance(
+            return BitmapRegionLoader.newInstance(
                     mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI), 0);
-            Cursor lastArtwork = mContext.getContentResolver().query(
-                    MuzeiContract.Artwork.CONTENT_URI, new String[] {BaseColumns._ID}, null, null, null);
-            if (lastArtwork != null && lastArtwork.moveToFirst()) {
-                long id = lastArtwork.getLong(0);
-                if (mLastLoadedArtworkId != id) {
-                    mLastLoadedArtworkId = id;
-                    NewWallpaperNotificationReceiver.maybeShowNewArtworkNotification(mContext);
-                    WearableController.updateArtwork(mContext);
-                }
-            }
-            if (lastArtwork != null) {
-                lastArtwork.close();
-            }
-            return loader;
         } catch (IOException e) {
             Log.e(TAG, "Error loading image", e);
             return null;


### PR DESCRIPTION
Move notification and Wearable artwork loading to rely solely on MuzeiProvider as source of truth. Instead of tying them into RealRenderController, they are now managed at the MuzeiWallpaperService level.

This also enables adding Source columns to any Artwork query (owing to the join it already does) as well as updates exactly how notification large icons/backgrounds are made - they are no longer square cropped.