### PR TITLE
Remove all instances of Class.getSimpleName() for logging

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
@@ -61,7 +61,7 @@ import java.util.LinkedHashSet;
  * Provides access to a the most recent artwork
  */
 public class MuzeiProvider extends ContentProvider {
-    private static final String TAG = MuzeiProvider.class.getSimpleName();
+    private static final String TAG = "MuzeiProvider";
     /**
      * The incoming URI matches the ARTWORK URI pattern
      */

--- a/example-contract-widget/src/main/java/com/example/muzei/examplecontractwidget/ArtworkUpdateService.java
+++ b/example-contract-widget/src/main/java/com/example/muzei/examplecontractwidget/ArtworkUpdateService.java
@@ -37,10 +37,10 @@ import java.io.FileNotFoundException;
  * Handle updating all widgets with the latest artwork
  */
 public class ArtworkUpdateService extends IntentService {
-    private static final String TAG = ArtworkUpdateService.class.getSimpleName();
+    private static final String TAG = "ArtworkUpdateService";
 
     public ArtworkUpdateService() {
-        super(ArtworkUpdateService.class.getSimpleName());
+        super(TAG);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class ArtworkUpdateService extends IntentService {
             // where options subsamples the image to the appropriate size if you don't need to full size image
             image = scaleBitmap(image);
         } catch (FileNotFoundException e) {
-            Log.w(ArtworkUpdateService.class.getSimpleName(), "Could not find current artwork image", e);
+            Log.w(TAG, "Could not find current artwork image", e);
             return;
         }
         if (image == null) {

--- a/example-watchface/src/main/java/com/example/muzei/watchface/ArtworkImageLoader.java
+++ b/example-watchface/src/main/java/com/example/muzei/watchface/ArtworkImageLoader.java
@@ -57,7 +57,7 @@ public class ArtworkImageLoader extends AsyncTaskLoader<Bitmap> {
         try {
             return MuzeiContract.Artwork.getCurrentArtworkBitmap(getContext());
         } catch (FileNotFoundException e) {
-            Log.e(ArtworkImageLoader.class.getSimpleName(), "Error getting artwork image", e);
+            Log.e("ArtworkImageLoader", "Error getting artwork image", e);
         }
         return null;
     }

--- a/main/src/main/java/com/google/android/apps/muzei/wearable/WearableSourceUpdateService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wearable/WearableSourceUpdateService.java
@@ -24,7 +24,7 @@ import android.content.Intent;
  */
 public class WearableSourceUpdateService extends IntentService {
     public WearableSourceUpdateService() {
-        super(WearableSourceUpdateService.class.getSimpleName());
+        super("WearableSourceUpdateService");
     }
 
     @Override

--- a/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class ActivateMuzeiIntentService extends IntentService {
-    private static final String TAG = ActivateMuzeiIntentService.class.getSimpleName();
+    private static final String TAG = "ActivateMuzeiService";
     private static final int NOTIFICATION_ID = 3113;
     private static final String ACTIVATE_MUZEI_NOTIF_SHOWN_PREF_KEY = "ACTIVATE_MUZEI_NOTIF_SHOWN";
     private static final String ACTION_MARK_NOTIFICATION_READ =

--- a/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  * notification to activate Muzei if the artwork is not found
  */
 public class ArtworkCacheIntentService extends IntentService {
-    private static final String TAG = ArtworkCacheIntentService.class.getSimpleName();
+    private static final String TAG = "ArtworkCacheService";
     public static final String SHOW_ACTIVATE_NOTIFICATION_EXTRA = "SHOW_ACTIVATE_NOTIFICATION";
 
     public ArtworkCacheIntentService() {

--- a/wearable/src/main/java/com/google/android/apps/muzei/FullScreenActivity.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/FullScreenActivity.java
@@ -46,7 +46,7 @@ import net.nurik.roman.muzei.R;
 import java.io.FileNotFoundException;
 
 public class FullScreenActivity extends Activity implements LoaderManager.LoaderCallbacks<Bitmap> {
-    private static final String TAG = FullScreenActivity.class.getSimpleName();
+    private static final String TAG = "FullScreenActivity";
 
     private PanView mPanView;
     private View mLoadingIndicatorView;

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -362,7 +362,7 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
         public void onVisibilityChanged(boolean visible) {
             super.onVisibilityChanged(visible);
             if (visible) {
-                mLoadImageHandlerThread = new HandlerThread(MuzeiWatchFace.class.getSimpleName());
+                mLoadImageHandlerThread = new HandlerThread("MuzeiWatchFace-LoadImage");
                 mLoadImageHandlerThread.start();
                 mLoadImageHandler = new Handler(mLoadImageHandlerThread.getLooper());
                 mLoadImageContentObserver = new LoadImageContentObserver(mLoadImageHandler);

--- a/wearable/src/main/java/com/google/android/apps/muzei/SourceChangedListenerService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/SourceChangedListenerService.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
  * WearableListenerService responsible to receiving Data Layer changes with updated source info
  */
 public class SourceChangedListenerService extends WearableListenerService {
-    private static final String TAG = SourceChangedListenerService.class.getSimpleName();
+    private static final String TAG = "SourceChangedService";
 
     @Override
     public void onDataChanged(final DataEventBuffer dataEvents) {

--- a/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
@@ -39,7 +39,7 @@ import android.widget.OverScroller;
  * and flinging
  */
 public class PanView extends View {
-    private static final String TAG = PanView.class.getSimpleName();
+    private static final String TAG = "PanView";
 
     private Bitmap mImage;
     private Bitmap mScaledImage;


### PR DESCRIPTION
While getSimpleName() is convenient, it falls apart when using ProGuard, which Muzei uses. Also caught a number of cases where the logging tag was more than the max 23 characters.