### PR TITLE
Fix complications, Wear image resizing

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -172,7 +172,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
             int width = options.outWidth;
             int height = options.outHeight;
             int shortestLength = Math.min(width, height);
-            options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = false;
             int largeIconHeight = context.getResources()
                     .getDimensionPixelSize(android.R.dimen.notification_large_icon_height);
             options.inSampleSize = ImageUtil.calculateSampleSize(shortestLength, largeIconHeight);

--- a/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
@@ -122,7 +122,7 @@ public class WearableController {
             options.inJustDecodeBounds = true;
             BitmapFactory.decodeStream(contentResolver.openInputStream(
                     MuzeiContract.Artwork.CONTENT_URI), null, options);
-            options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = false;
             if (options.outWidth > options.outHeight) {
                 options.inSampleSize = ImageUtil.calculateSampleSize(options.outHeight, 320);
             } else {

--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
@@ -70,6 +70,8 @@ public class ArtworkComplicationJobService extends JobService {
             }
             providerUpdateRequester.requestUpdate(complicationIds);
         }
+        // Schedule the job again to catch the next update to the artwork
+        scheduleComplicationUpdateJob(this);
         return false;
     }
 


### PR DESCRIPTION
Fixes issues where
- JobService's started with `addTriggerContentUri` need to be manually rescheduled after they are triggered as per documentation
- Complications falling out of sync with SharedPreferences when uninstalled/reinstalled
- Images being synced to Wear not properly resized down to ~320 pixels