### PR TITLE
Update to Support library 24.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,5 +20,5 @@ ext {
     buildToolsVersion = "24.0.1"
     targetSdkVersion = 23
 
-    supportLibraryVersion = "24.1.1"
+    supportLibraryVersion = "24.2.0"
 }


### PR DESCRIPTION
Update to the latest Support Library 24.2.0. Use DiffUtil to build the correct notify() calls for when the Gallery's URIs change