### PR TITLE
Ensure MuzeiArtSource publishes prior to being destroyed, min API 18

### DIFF
--- a/api/src/main/java/com/google/android/apps/muzei/api/MuzeiArtSource.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/MuzeiArtSource.java
@@ -346,7 +346,7 @@ public abstract class MuzeiArtSource extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        mServiceLooper.quit();
+        mServiceLooper.quitSafely();
     }
 
     /**

--- a/example-contract-widget/build.gradle
+++ b/example-contract-widget/build.gradle
@@ -39,7 +39,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 18
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
 }

--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -41,7 +41,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
 }

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -42,7 +42,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 18
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
 

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -43,7 +43,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 18
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
 


### PR DESCRIPTION
HandlerThread.quit() will drop pending messages, potentially dropping the final published update as the IntentService is stopped. Switch to API 18's quitSafely() method to ensure any pending publishes are actually done.