### PR TITLE
Handle art sources without an android:description

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
@@ -331,7 +331,7 @@ public class MuzeiDocumentsProvider extends DocumentsProvider {
             String title = resolveInfo.loadLabel(packageManager).toString();
             row.add(DocumentsContract.Document.COLUMN_DISPLAY_NAME, title);
             String description = data.getString(data.getColumnIndex(MuzeiContract.Sources.COLUMN_NAME_DESCRIPTION));
-            if (TextUtils.isEmpty(description)) {
+            if (TextUtils.isEmpty(description) && resolveInfo.serviceInfo.descriptionRes != 0) {
                 // Load the default description
                 try {
                     Context packageContext = context.createPackageContext(

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
@@ -368,14 +368,15 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
             source.icon = new BitmapDrawable(getResources(), generateSourceImage(ri.loadIcon(pm)));
             source.componentName = new ComponentName(ri.serviceInfo.packageName,
                     ri.serviceInfo.name);
-            Context packageContext;
-            try {
-                packageContext = getActivity().createPackageContext(
-                        source.componentName.getPackageName(), 0);
-                Resources packageRes = packageContext.getResources();
-                source.description = packageRes.getString(ri.serviceInfo.descriptionRes);
-            } catch (PackageManager.NameNotFoundException e) {
-                Log.e(TAG, "Can't read package resources for source " + source.componentName);
+            if (ri.serviceInfo.descriptionRes != 0) {
+                try {
+                    Context packageContext = getActivity().createPackageContext(
+                            source.componentName.getPackageName(), 0);
+                    Resources packageRes = packageContext.getResources();
+                    source.description = packageRes.getString(ri.serviceInfo.descriptionRes);
+                } catch (PackageManager.NameNotFoundException e) {
+                    Log.e(TAG, "Can't read package resources for source " + source.componentName);
+                }
             }
             Bundle metaData = ri.serviceInfo.metaData;
             source.color = Color.WHITE;


### PR DESCRIPTION
We can safely assume that apps without an android:description on their MuzeiArtSource don't want a description shown (perhaps they are setting it at runtime). Don't crash Muzei in this cases. Fixes GH-165