### PR TITLE
Move artwork retries to use JobScheduler on API 21+

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -62,6 +62,10 @@
         <service android:name="com.google.android.apps.muzei.wearable.WearableSourceUpdateService" />
 
         <service android:name="com.google.android.apps.muzei.TaskQueueService" />
+        <service
+            android:name="com.google.android.apps.muzei.sync.DownloadArtworkJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true"/>
 
         <activity android:name="com.google.android.apps.muzei.settings.SettingsActivity"
             android:label="@string/settings_title"

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
 
         <service android:name="com.google.android.apps.muzei.wearable.WearableSourceUpdateService" />
 
-        <service android:name="com.google.android.apps.muzei.TaskQueueService" />
+        <service android:name="com.google.android.apps.muzei.sync.TaskQueueService" />
         <service
             android:name="com.google.android.apps.muzei.sync.DownloadArtworkJobService"
             android:permission="android.permission.BIND_JOB_SERVICE"

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -68,6 +68,7 @@ import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
 import com.google.android.apps.muzei.event.WallpaperSizeChangedEvent;
 import com.google.android.apps.muzei.render.MuzeiRendererFragment;
 import com.google.android.apps.muzei.settings.SettingsActivity;
+import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.util.AnimatedMuzeiLoadingSpinnerView;
 import com.google.android.apps.muzei.util.AnimatedMuzeiLogoFragment;
 import com.google.android.apps.muzei.util.CheatSheet;

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -39,6 +39,7 @@ import com.google.android.apps.muzei.event.WallpaperSizeChangedEvent;
 import com.google.android.apps.muzei.render.MuzeiBlurRenderer;
 import com.google.android.apps.muzei.render.RealRenderController;
 import com.google.android.apps.muzei.render.RenderController;
+import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.wearable.WearableController;
 
 import net.rbgrn.android.glwallpaperservice.GLWallpaperService;

--- a/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.android.apps.muzei.sync.TaskQueueService;
 
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.ACTION_NETWORK_AVAILABLE;
 

--- a/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NetworkChangeReceiver.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
+import android.os.Build;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
@@ -35,9 +36,11 @@ public class NetworkChangeReceiver extends WakefulBroadcastReceiver {
         if (hasConnectivity) {
             // Check with components that may not currently be alive but interested in
             // network connectivity changes.
-            Intent retryIntent = TaskQueueService.maybeRetryDownloadDueToGainedConnectivity(context);
-            if (retryIntent != null) {
-                startWakefulService(context, retryIntent);
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                Intent retryIntent = TaskQueueService.maybeRetryDownloadDueToGainedConnectivity(context);
+                if (retryIntent != null) {
+                    startWakefulService(context, retryIntent);
+                }
             }
 
             // TODO: wakeful broadcast?

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -38,6 +38,7 @@ import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.android.apps.muzei.api.UserCommand;
 import com.google.android.apps.muzei.api.internal.SourceState;
 import com.google.android.apps.muzei.featuredart.FeaturedArtSource;
+import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.wearable.WearableController;
 import com.google.android.apps.muzei.wearable.WearableSourceUpdateService;
 

--- a/main/src/main/java/com/google/android/apps/muzei/TaskQueueService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/TaskQueueService.java
@@ -19,9 +19,13 @@ package com.google.android.apps.muzei;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.SystemClock;
@@ -29,13 +33,18 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
+import com.google.android.apps.muzei.sync.DownloadArtworkJobService;
 import com.google.android.apps.muzei.sync.DownloadArtworkTask;
+
+import java.util.List;
 
 public class TaskQueueService extends Service {
     private static final String TAG = "TaskQueueService";
 
     static final String ACTION_DOWNLOAD_CURRENT_ARTWORK
             = "com.google.android.apps.muzei.action.DOWNLOAD_CURRENT_ARTWORK";
+
+    private static final int LOAD_ARTWORK_JOB_ID = 1;
 
     private static final String PREF_ARTWORK_DOWNLOAD_ATTEMPT = "artwork_download_attempt";
 
@@ -90,7 +99,7 @@ public class TaskQueueService extends Service {
         return START_REDELIVER_INTENT;
     }
 
-    static PendingIntent getArtworkDownloadRetryPendingIntent(Context context) {
+    private static PendingIntent getArtworkDownloadRetryPendingIntent(Context context) {
         return PendingIntent.getService(context, 0,
                 getDownloadCurrentArtworkIntent(context),
                 PendingIntent.FLAG_UPDATE_CURRENT);
@@ -102,24 +111,46 @@ public class TaskQueueService extends Service {
     }
 
     private void cancelArtworkDownloadRetries() {
-        AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-        am.cancel(TaskQueueService.getArtworkDownloadRetryPendingIntent(this));
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-        sp.edit().putInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, 0).commit();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            JobScheduler jobScheduler = (JobScheduler) getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            jobScheduler.cancel(LOAD_ARTWORK_JOB_ID);
+        } else {
+            AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+            am.cancel(TaskQueueService.getArtworkDownloadRetryPendingIntent(this));
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+            sp.edit().putInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, 0).commit();
+        }
     }
 
     private void scheduleRetryArtworkDownload() {
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-        int reloadAttempt = sp.getInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, 0);
-        sp.edit().putInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, reloadAttempt + 1).commit();
-
-        AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-        long retryTimeMillis = SystemClock.elapsedRealtime() + (1 << reloadAttempt) * 2000;
-        am.set(AlarmManager.ELAPSED_REALTIME, retryTimeMillis,
-                TaskQueueService.getArtworkDownloadRetryPendingIntent(this));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            JobScheduler jobScheduler = (JobScheduler) getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            jobScheduler.schedule(new JobInfo.Builder(LOAD_ARTWORK_JOB_ID,
+                    new ComponentName(this, DownloadArtworkJobService.class))
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .build());
+        } else {
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+            int reloadAttempt = sp.getInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, 0);
+            sp.edit().putInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, reloadAttempt + 1).commit();
+            AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+            long retryTimeMillis = SystemClock.elapsedRealtime() + (1 << reloadAttempt) * 2000;
+            am.set(AlarmManager.ELAPSED_REALTIME, retryTimeMillis,
+                    TaskQueueService.getArtworkDownloadRetryPendingIntent(this));
+        }
     }
 
     public static Intent maybeRetryDownloadDueToGainedConnectivity(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            List<JobInfo> pendingJobs = jobScheduler.getAllPendingJobs();
+            for (JobInfo pendingJob : pendingJobs) {
+                if (pendingJob.getId() == LOAD_ARTWORK_JOB_ID) {
+                    return TaskQueueService.getDownloadCurrentArtworkIntent(context);
+                }
+            }
+            return null;
+        }
         return (PreferenceManager.getDefaultSharedPreferences(context)
                 .getInt(PREF_ARTWORK_DOWNLOAD_ATTEMPT, 0) > 0)
                 ? TaskQueueService.getDownloadCurrentArtworkIntent(context)

--- a/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkJobService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkJobService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.sync;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+
+/**
+ * JobService that handles reloading artwork after any initial failure
+ */
+public class DownloadArtworkJobService extends JobService {
+    private DownloadArtworkTask mDownloadArtworkTask = null;
+
+    @Override
+    public boolean onStartJob(final JobParameters params) {
+        mDownloadArtworkTask = new DownloadArtworkTask(this) {
+            @Override
+            protected void onPostExecute(Boolean success) {
+                jobFinished(params, !success);
+            }
+        };
+        mDownloadArtworkTask.execute();
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(final JobParameters params) {
+        if (mDownloadArtworkTask != null) {
+            mDownloadArtworkTask.cancel(true);
+        }
+        return true;
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/sync/TaskQueueService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/TaskQueueService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.apps.muzei;
+package com.google.android.apps.muzei.sync;
 
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -32,9 +32,6 @@ import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v4.content.WakefulBroadcastReceiver;
-
-import com.google.android.apps.muzei.sync.DownloadArtworkJobService;
-import com.google.android.apps.muzei.sync.DownloadArtworkTask;
 
 import java.util.List;
 


### PR DESCRIPTION
Instead of retrying whenever the network connectivity changes, use JobScheduler to schedule the retry job and backoff logic.