### PR TITLE
Gallery: Use URI Based Permissions instead of storing a copy when possible

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -172,6 +172,9 @@ public class MuzeiActivity extends AppCompatActivity {
                     @Override
                     public void onClick(View view) {
                         viewIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        // Make sure any data URIs granted to Muzei are passed onto the
+                        // started Activity
+                        viewIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         try {
                             startActivity(viewIntent);
                         } catch (ActivityNotFoundException | SecurityException e) {

--- a/source-gallery/src/main/AndroidManifest.xml
+++ b/source-gallery/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
         <provider
             android:authorities="${galleryAuthority}"
             android:name="com.google.android.apps.muzei.gallery.GalleryProvider"
-            android:exported="false" />
+            android:exported="false"
+            android:grantUriPermissions="true"/>
         <service android:name="com.google.android.apps.muzei.gallery.GalleryArtSource"
                  android:label="@string/gallery_title"
                  android:description="@string/gallery_description"

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
@@ -315,7 +315,7 @@ public class GalleryArtSource extends MuzeiArtSource {
             ContentValues values = new ContentValues();
             values.put(GalleryContract.MetadataCache.COLUMN_NAME_URI, imageUri.toString());
 
-            File imageFile = GalleryProvider.getLocalFileForUri(this, imageUri.toString());
+            File imageFile = GalleryProvider.getLocalFileForUri(this, imageUri);
             if (imageFile == null) {
                 return;
             }

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -30,6 +30,7 @@ import android.content.Intent;
 import android.content.OperationApplicationException;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
@@ -78,6 +79,7 @@ import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.android.apps.muzei.gallery.GalleryArtSource.ACTION_PUBLISH_NEXT_GALLERY_ITEM;
@@ -286,6 +288,19 @@ public class GallerySettingsActivity extends AppCompatActivity
                 item.setChecked(true);
             }
         }
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(final Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("image/*");
+        List<ResolveInfo> getContentActivities = getPackageManager().queryIntentActivities(intent, 0);
+        // Don't show the 'Import photos' action unless there are enabled activities that specifically only
+        // support ACTION_GET_CONTENT (size must be > 1 as the default DocumentsActivity will always appear in this
+        // list on API 19+ devices)
+        menu.findItem(R.id.action_import_photos).setVisible(getContentActivities.size() > 1);
         return true;
     }
 

--- a/source-gallery/src/main/res/menu/gallery_activity.xml
+++ b/source-gallery/src/main/res/menu/gallery_activity.xml
@@ -44,6 +44,9 @@
         </menu>
     </item>
     <item
+        android:id="@+id/action_import_photos"
+        android:title="@string/gallery_action_import_photos" />
+    <item
         android:id="@+id/action_clear_photos"
         android:title="@string/gallery_action_clear_photos"
         android:orderInCategory="10000"

--- a/source-gallery/src/main/res/values/strings.xml
+++ b/source-gallery/src/main/res/values/strings.xml
@@ -24,6 +24,13 @@
     <string name="gallery_action_rotate_interval_6h">Every 6 hours</string>
     <string name="gallery_action_rotate_interval_24h">Every 24 hours</string>
     <string name="gallery_action_rotate_interval_72h">Every 3 days</string>
+    <string name="gallery_action_import_photos">Import photos</string>
+
+    <string name="gallery_import_warning_title">Use additional storage space?</string>
+    <string name="gallery_import_warning_message">Importing creates additional copies of your photos and does not
+        sync edits or deletions. Use this option if your app does not appear in the default list.</string>
+    <string name="gallery_import_warning_continue">Proceed with import</string>
+    <string name="gallery_import_warning_cancel">Cancel</string>
 
     <string name="gallery_action_force_now">Set as wallpaper now</string>
     <string name="gallery_action_remove">Remove</string>


### PR DESCRIPTION
Change the default action for adding photos to be `ACTION_OPEN_DOCUMENT` instead of `ACTION_GET_CONTENT`. This allows the Gallery extension to use URI based permissions to read the selected images on demand rather than store a copy of each and every photo selected (which led to a large amount of storage space used for large photo galleries).

In addition, this ensures that photos that are deleted or changed in the source are reflected in the Gallery.

A new menu item is added to the overflow menu that allows users to 'Import Photos' using `ACTION_GET_CONTENT` to support apps still using a `GET_CONTENT` Activity, with a warning of the downsides beforehand.