### PR TITLE
Improve the workflow for importing photos with GET_CONTENT

### DIFF
--- a/source-gallery/src/main/res/values/strings.xml
+++ b/source-gallery/src/main/res/values/strings.xml
@@ -24,13 +24,10 @@
     <string name="gallery_action_rotate_interval_6h">Every 6 hours</string>
     <string name="gallery_action_rotate_interval_24h">Every 24 hours</string>
     <string name="gallery_action_rotate_interval_72h">Every 3 days</string>
-    <string name="gallery_action_import_photos">Import photos</string>
+    <string name="gallery_action_import_photos">Import photos…</string>
+    <string name="gallery_action_import_photos_from">Import photos from %s</string>
 
-    <string name="gallery_import_warning_title">Use additional storage space?</string>
-    <string name="gallery_import_warning_message">Importing creates additional copies of your photos and does not
-        sync edits or deletions. Use this option if your app does not appear in the default list.</string>
-    <string name="gallery_import_warning_continue">Proceed with import</string>
-    <string name="gallery_import_warning_cancel">Cancel</string>
+    <string name="gallery_import_dialog_title">Import photos from</string>
 
     <string name="gallery_action_force_now">Set as wallpaper now</string>
     <string name="gallery_action_remove">Remove</string>


### PR DESCRIPTION
The previous workflow for importing photos had a number of downsides:
- The warning dialog felt punitive towards the user even though it wasn't their choice that the app they want to use only supports GET_CONTENT
- The standard Storage Access Framework UI allowed users to import photos that they should really be adding via ACTION_OPEN_DOCUMENT

Since we can query the exact activities supporting GET_CONTENT, we can improve the workflow by:
- Handling only one app by directly starting that Activity
- Handling more than one app by having the user choose which app they want to import photos from

This has the side benefit that there is no need for a scary dialog anymore and photos cannot be imported if adding them directly is an option