### PR TITLE
Upgrade to latest build tools, Support Library, and Google Play services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@
 ext {
     gradleClasspath = 'com.android.tools.build:gradle:2.2.0'
     compileSdkVersion = 24
-    buildToolsVersion = "24.0.1"
+    buildToolsVersion = "24.0.3"
     targetSdkVersion = 23
 
-    supportLibraryVersion = "24.2.0"
+    supportLibraryVersion = "24.2.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,4 +21,7 @@ ext {
     targetSdkVersion = 23
 
     supportLibraryVersion = "24.2.1"
+    googlePlayServicesVersion = "9.6.1"
+    okhttpVersion = "3.4.1"
+    picassoVersion = "2.5.2"
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -116,7 +116,7 @@ android {
 dependencies {
     compile "com.squareup.okhttp3:okhttp:3.4.1"
     compile "com.squareup.picasso:picasso:2.5.2"
-    compile "com.google.android.gms:play-services-wearable:9.4.0"
+    compile "com.google.android.gms:play-services-wearable:9.6.1"
     compile "org.greenrobot:eventbus:3.0.0"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -114,9 +114,9 @@ android {
 }
 
 dependencies {
-    compile "com.squareup.okhttp3:okhttp:3.4.1"
-    compile "com.squareup.picasso:picasso:2.5.2"
-    compile "com.google.android.gms:play-services-wearable:9.6.1"
+    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
+    compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
+    compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
     compile "org.greenrobot:eventbus:3.0.0"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     compile project(':api')
-    compile "com.squareup.okhttp3:okhttp:3.4.1"
+    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
     compile "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
 }
 

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     compile project(':api')
-    compile "com.squareup.okhttp3:okhttp:3.4.1"
-    compile "com.squareup.picasso:picasso:2.5.2"
+    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
+    compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"


### PR DESCRIPTION
Upgrade to the latest version of the libraries used. Centralize shared libraries into the top level Gradle file to ease future maintenance.