### PR TITLE
Ensure that ACTION_ARTWORK_CHANGED broadcasts work

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
@@ -243,7 +243,8 @@ public class MuzeiProvider extends ContentProvider {
                 return;
             }
             context.getContentResolver().notifyChange(uri, null);
-            if (MuzeiContract.Artwork.CONTENT_URI.equals(uri)) {
+            if (MuzeiProvider.uriMatcher.match(uri) == ARTWORK ||
+                    MuzeiProvider.uriMatcher.match(uri) == ARTWORK_ID) {
                 context.sendBroadcast(new Intent(MuzeiContract.Artwork.ACTION_ARTWORK_CHANGED));
             } else if (MuzeiProvider.uriMatcher.match(uri) == SOURCES ||
                     MuzeiProvider.uriMatcher.match(uri) == SOURCE_ID) {


### PR DESCRIPTION
With the changes in loading data, both ARTWORK and ARTWORK_ID URIs are passed to notifyChange(). This fixes ARTWORK_CHANGED broadcasts so that they happen on both types of URIs.