### PR TITLE
Removes unnecessary LinearLayout from settings_ab_spinner_list_item

### DIFF
--- a/main/src/main/res/layout/settings_ab_spinner_list_item.xml
+++ b/main/src/main/res/layout/settings_ab_spinner_list_item.xml
@@ -14,14 +14,9 @@
   limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
-
-    <TextView
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@android:id/text1"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:drawablePadding="8dp"
         android:drawableEnd="@drawable/spinner_triangle"
@@ -31,4 +26,3 @@
         android:maxLines="1"
         android:textAppearance="@style/TextAppearance.ActionBar.Title" />
 
-</LinearLayout>


### PR DESCRIPTION
Removes unnecessary LinearLayout from settings_ab_spinner_list_item

# Before
![screenshot_20161008-143038](https://cloud.githubusercontent.com/assets/802308/19215194/1ce4f8d0-8d65-11e6-89e4-7c79df5c308f.png)

# After
![screenshot_20161008-143024](https://cloud.githubusercontent.com/assets/802308/19215195/22aac7fe-8d65-11e6-8a68-f819239e51e7.png)
