### PR TITLE
Split main APKs by ABI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,7 @@ ext {
     googlePlayServicesVersion = "9.6.1"
     okhttpVersion = "3.4.1"
     picassoVersion = "2.5.2"
+
+    abiSplitMultiplier = 10000
+    abiSplitVersionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'mips':3, 'x86':4, 'x86_64':5]
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -63,6 +63,25 @@ android {
         }
     }
 
+    splits {
+        abi {
+            enable true
+            reset()
+            include "armeabi-v7a", "arm64-v8a", "mips", "x86", "x86_64"
+            universalApk true
+        }
+    }
+
+    // For each APK output variant, add in the ABI specific versionCode
+    applicationVariants.all { variant ->
+        // assign different version code for each output
+        variant.outputs.each { output ->
+            int abiVersionCode = rootProject.ext.abiSplitVersionCodes.get(
+                    output.getFilter(com.android.build.OutputFile.ABI)) ?: 0
+            output.versionCodeOverride = abiVersionCode * rootProject.ext.abiSplitMultiplier + defaultConfig.versionCode
+        }
+    }
+
     productFlavors {
         dev {
             // dev utilizes minSDKVersion = 21 to allow the Android gradle plugin


### PR DESCRIPTION
As Renderscript includes native libraries that constitute 45%+ of the total APK size, provide split APKs that only package in exactly the native library that is needed for that device.