### PR TITLE
Split Wear versioning from phone versioning

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 
-code = 2010
-name = 2.2
+name = 2.3
+# Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
+codeWear = 2300
+# Add one to codeWear to ensure a unique version code for the main app
+code = 2301
 
 # Latest beta number for this version. Only applies to beta builds.
 betaNumber = Beta 1

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -41,7 +41,7 @@ android {
         renderscriptSupportModeEnabled true
 
         versionName versionProps['name']
-        versionCode versionProps['code'].toInteger()
+        versionCode versionProps['codeWear'].toInteger()
     }
 
     signingConfigs {


### PR DESCRIPTION
When it comes to publishing Wear 2.0 directly to the Play Store, they must have a separate version code from the phone app to support multiple APKs.