### PR TITLE
Add Firebase Crash+Analytics

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     }
     dependencies {
         classpath rootProject.ext.gradleClasspath
+        classpath 'com.google.gms:google-services:3.0.0'
     }
 }
 
@@ -136,6 +137,7 @@ dependencies {
     compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
     compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
     compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
     compile "org.greenrobot:eventbus:3.0.0"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
@@ -150,3 +152,5 @@ dependencies {
     devWearApp project(path: ':wearable', configuration: 'devRelease')
     prodWearApp project(path: ':wearable', configuration: 'prodRelease')
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/main/google-services.json
+++ b/main/google-services.json
@@ -1,0 +1,55 @@
+{
+  "project_info": {
+    "project_number": "543408482564",
+    "firebase_url": "https://project-5314359277299065051.firebaseio.com",
+    "project_id": "project-5314359277299065051",
+    "storage_bucket": "project-5314359277299065051.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:543408482564:android:b94fc70ed09b1238",
+        "android_client_info": {
+          "package_name": "net.nurik.roman.muzei"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "543408482564-t831s05qt0nffpp5k3l043dukif9l4tg.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "net.nurik.roman.muzei",
+            "certificate_hash": "FF265DBDE0B46E5A8853D88791ED546595F0DEAB"
+          }
+        },
+        {
+          "client_id": "543408482564-lhkad8drrvnjqupeoifdq2bqfhto9b0t.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB6YOyyg_RZB9w8TBNXY5Wm-QJxxZWSn2M"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "543408482564-lhkad8drrvnjqupeoifdq2bqfhto9b0t.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     }
     dependencies {
         classpath rootProject.ext.gradleClasspath
+        classpath 'com.google.gms:google-services:3.0.0'
     }
 }
 
@@ -89,6 +90,9 @@ android {
 
 dependencies {
     compile "com.google.android.support:wearable:2.0.0-alpha2"
-    compile "com.google.android.gms:play-services-wearable:8.4.0"
+    compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
     compile project(':android-client-common')
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/wearable/google-services.json
+++ b/wearable/google-services.json
@@ -1,0 +1,55 @@
+{
+  "project_info": {
+    "project_number": "543408482564",
+    "firebase_url": "https://project-5314359277299065051.firebaseio.com",
+    "project_id": "project-5314359277299065051",
+    "storage_bucket": "project-5314359277299065051.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:543408482564:android:b94fc70ed09b1238",
+        "android_client_info": {
+          "package_name": "net.nurik.roman.muzei"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "543408482564-t831s05qt0nffpp5k3l043dukif9l4tg.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "net.nurik.roman.muzei",
+            "certificate_hash": "FF265DBDE0B46E5A8853D88791ED546595F0DEAB"
+          }
+        },
+        {
+          "client_id": "543408482564-lhkad8drrvnjqupeoifdq2bqfhto9b0t.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB6YOyyg_RZB9w8TBNXY5Wm-QJxxZWSn2M"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "543408482564-lhkad8drrvnjqupeoifdq2bqfhto9b0t.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
Adds Firebase Crash and Firebase Analytics to both the phone/tablet app and the Wear app to allow better measurement of usage.

Only the basics right now: no custom analytics/crash logging