### PR TITLE
Centralize the Tools and Google Services Plugin versions

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,8 @@
  */
 
 ext {
-    gradleClasspath = 'com.android.tools.build:gradle:2.2.0'
+    toolsPluginVersion = "2.2.1"
+    googleServicesPluginVersion = "3.0.0"
     compileSdkVersion = 24
     buildToolsVersion = "24.0.3"
     targetSdkVersion = 23

--- a/example-contract-widget/build.gradle
+++ b/example-contract-widget/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/example-watchface/build.gradle
+++ b/example-watchface/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,8 +19,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
+        classpath "com.google.gms:google-services:$rootProject.ext.googleServicesPluginVersion"
     }
 }
 

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
     }
 }
 

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -19,8 +19,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath rootProject.ext.gradleClasspath
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath "com.android.tools.build:gradle:$rootProject.ext.toolsPluginVersion"
+        classpath "com.google.gms:google-services:$rootProject.ext.googleServicesPluginVersion"
     }
 }
 


### PR DESCRIPTION
Move the tools and Google Services Gradle plugin versions into the root project. Use the same format for all of them (only keep the version number in the root project).