### PR TITLE
Add basic analytics and user properties

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -48,6 +48,8 @@ android {
 
         versionName versionProps['name']
         versionCode versionProps['code'].toInteger()
+
+        buildConfigField "String", "DEVICE_TYPE", "\"android\""
     }
 
     signingConfigs {

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -76,6 +76,7 @@ import com.google.android.apps.muzei.util.DrawInsetsFrameLayout;
 import com.google.android.apps.muzei.util.PanScaleProxyView;
 import com.google.android.apps.muzei.util.ScrimUtil;
 import com.google.android.apps.muzei.util.TypefaceUtil;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -322,6 +323,7 @@ public class MuzeiActivity extends AppCompatActivity {
         findViewById(R.id.activate_muzei_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                FirebaseAnalytics.getInstance(MuzeiActivity.this).logEvent("activate", null);
                 try {
                     startActivity(new Intent(WallpaperManager.ACTION_CHANGE_LIVE_WALLPAPER)
                             .putExtra(WallpaperManager.EXTRA_LIVE_WALLPAPER_COMPONENT,
@@ -418,6 +420,7 @@ public class MuzeiActivity extends AppCompatActivity {
 
         // Special work
         if (newUiMode == UI_MODE_INTRO) {
+            FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.TUTORIAL_BEGIN, null);
             final View activateButton = findViewById(R.id.activate_muzei_button);
             activateButton.setAlpha(0);
             final AnimatedMuzeiLogoFragment logoFragment = (AnimatedMuzeiLogoFragment)
@@ -511,6 +514,10 @@ public class MuzeiActivity extends AppCompatActivity {
                 });
             }
             set.start();
+        }
+
+        if (newUiMode == UI_MODE_ART_DETAIL) {
+            FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.TUTORIAL_COMPLETE, null);
         }
 
         mPanScaleProxyView.setVisibility(newUiMode == UI_MODE_ART_DETAIL

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -78,6 +78,7 @@ import com.google.android.apps.muzei.util.ScrimUtil;
 import com.google.android.apps.muzei.util.TypefaceUtil;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
+import net.nurik.roman.muzei.BuildConfig;
 import net.nurik.roman.muzei.R;
 
 import java.util.List;
@@ -259,6 +260,7 @@ public class MuzeiActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.muzei_activity);
+        FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
 
         mContainerView = (DrawInsetsFrameLayout) findViewById(R.id.container);
 

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -697,6 +697,7 @@ public class MuzeiActivity extends AppCompatActivity {
 
                 switch (menuItem.getItemId()) {
                     case R.id.action_settings:
+                        FirebaseAnalytics.getInstance(MuzeiActivity.this).logEvent("settings_open", null);
                         startActivity(new Intent(MuzeiActivity.this, SettingsActivity.class));
                         return true;
                 }

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -41,7 +41,9 @@ import com.google.android.apps.muzei.render.RealRenderController;
 import com.google.android.apps.muzei.render.RenderController;
 import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.wearable.WearableController;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
+import net.nurik.roman.muzei.BuildConfig;
 import net.rbgrn.android.glwallpaperservice.GLWallpaperService;
 
 import org.greenrobot.eventbus.EventBus;
@@ -63,6 +65,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
     @Override
     public void onCreate() {
         super.onCreate();
+        FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
         mLockScreenVisibleReceiver = new LockScreenVisibleReceiver();
         mLockScreenVisibleReceiver.setupRegisterDeregister(this);
         SourceManager.getInstance(MuzeiWallpaperService.this).subscribeToSelectedSource();

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -153,6 +153,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
 
             mGestureDetector = new GestureDetector(MuzeiWallpaperService.this, mGestureListener);
             if (!isPreview()) {
+                FirebaseAnalytics.getInstance(MuzeiWallpaperService.this).logEvent("wallpaper_created", null);
                 EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(true));
             }
             setTouchEventsEnabled(true);
@@ -174,6 +175,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
             super.onDestroy();
             EventBus.getDefault().unregister(this);
             if (!isPreview()) {
+                FirebaseAnalytics.getInstance(MuzeiWallpaperService.this).logEvent("wallpaper_destroyed", null);
                 EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(false));
             }
             queueEvent(new Runnable() {

--- a/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
@@ -25,9 +25,7 @@ import android.os.Bundle;
 
 import com.google.android.apps.muzei.gallery.GalleryArtSource;
 import com.google.android.apps.muzei.gallery.GalleryContract;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 public class PhotoSetAsTargetActivity extends Activity {
     @Override
@@ -41,6 +39,11 @@ public class PhotoSetAsTargetActivity extends Activity {
         Uri photoUri = getIntent().getData();
 
         // Select the gallery source
+        Bundle bundle = new Bundle();
+        bundle.putString(FirebaseAnalytics.Param.ITEM_ID,
+                new ComponentName(this, GalleryArtSource.class).flattenToShortString());
+        bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
+        FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
         SourceManager sourceManager = SourceManager.getInstance(this);
         sourceManager.selectSource(new ComponentName(this, GalleryArtSource.class));
 

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -41,6 +41,7 @@ import com.google.android.apps.muzei.featuredart.FeaturedArtSource;
 import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.wearable.WearableController;
 import com.google.android.apps.muzei.wearable.WearableSourceUpdateService;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.BuildConfig;
 
@@ -68,7 +69,7 @@ public class SourceManager {
     private static final String PREF_SELECTED_SOURCE = "selected_source";
     private static final String PREF_SELECTED_SOURCE_TOKEN = "selected_source_token";
     private static final String PREF_SOURCE_STATES = "source_states";
-
+    private static final String USER_PROPERTY_SELECTED_SOURCE = "selected_source";
     private Context mApplicationContext;
     private ComponentName mSubscriberComponentName;
     private SharedPreferences mSharedPrefs;
@@ -159,6 +160,8 @@ public class SourceManager {
         try {
             mContentResolver.applyBatch(MuzeiContract.AUTHORITY, operations);
             mSharedPrefs.edit().remove(PREF_SELECTED_SOURCE).remove(PREF_SOURCE_STATES).apply();
+            FirebaseAnalytics.getInstance(mApplicationContext).setUserProperty(USER_PROPERTY_SELECTED_SOURCE,
+                    selectedSource.flattenToShortString());
             mApplicationContext.startService(
                     new Intent(mApplicationContext, WearableSourceUpdateService.class));
         } catch (RemoteException | OperationApplicationException e) {
@@ -217,6 +220,8 @@ public class SourceManager {
                         .putString(PREF_SELECTED_SOURCE, source.flattenToShortString())
                         .putString(PREF_SELECTED_SOURCE_TOKEN, mSelectedSourceToken)
                         .apply();
+                FirebaseAnalytics.getInstance(mApplicationContext).setUserProperty(USER_PROPERTY_SELECTED_SOURCE,
+                        source.flattenToShortString());
                 mApplicationContext.startService(
                         new Intent(mApplicationContext, WearableSourceUpdateService.class));
             } catch (RemoteException | OperationApplicationException e) {

--- a/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
@@ -53,6 +53,11 @@ public class NextArtworkTileService extends TileService {
     private boolean mWallpaperActive = false;
 
     @Override
+    public void onTileAdded() {
+        FirebaseAnalytics.getInstance(this).logEvent("tile_next_artwork_added", null);
+    }
+
+    @Override
     public void onStartListening() {
         // Start listening for source changes, which will include when a source
         // starts or stops supporting the 'Next Artwork' command
@@ -149,5 +154,10 @@ public class NextArtworkTileService extends TileService {
     public void onStopListening() {
         EventBus.getDefault().unregister(this);
         getContentResolver().unregisterContentObserver(mSourceContentObserver);
+    }
+
+    @Override
+    public void onTileRemoved() {
+        FirebaseAnalytics.getInstance(this).logEvent("tile_next_artwork_removed", null);
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
@@ -35,6 +35,7 @@ import com.google.android.apps.muzei.SourceManager;
 import com.google.android.apps.muzei.api.MuzeiArtSource;
 import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -123,6 +124,7 @@ public class NextArtworkTileService extends TileService {
             unlockAndRun(new Runnable() {
                 @Override
                 public void run() {
+                    FirebaseAnalytics.getInstance(NextArtworkTileService.this).logEvent("activate_tile", null);
                     try {
                         startActivityAndCollapse(new Intent(WallpaperManager.ACTION_CHANGE_LIVE_WALLPAPER)
                                 .putExtra(WallpaperManager.EXTRA_LIVE_WALLPAPER_COMPONENT,

--- a/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
@@ -122,6 +122,8 @@ public class NextArtworkTileService extends TileService {
     @Override
     public void onClick() {
         if (getQsTile().getState() == Tile.STATE_ACTIVE) {
+            FirebaseAnalytics.getInstance(NextArtworkTileService.this).logEvent(
+                    "tile_next_artwork_click", null);
             // Active means we send the 'Next Artwork' command
             SourceManager.getInstance(this).sendAction(MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
         } else {
@@ -129,7 +131,8 @@ public class NextArtworkTileService extends TileService {
             unlockAndRun(new Runnable() {
                 @Override
                 public void run() {
-                    FirebaseAnalytics.getInstance(NextArtworkTileService.this).logEvent("activate_tile", null);
+                    FirebaseAnalytics.getInstance(NextArtworkTileService.this).logEvent(
+                            "tile_next_artwork_activate", null);
                     try {
                         startActivityAndCollapse(new Intent(WallpaperManager.ACTION_CHANGE_LIVE_WALLPAPER)
                                 .putExtra(WallpaperManager.EXTRA_LIVE_WALLPAPER_COMPONENT,

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
@@ -44,6 +44,7 @@ import android.widget.Toast;
 import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
 import com.google.android.apps.muzei.render.MuzeiRendererFragment;
 import com.google.android.apps.muzei.util.DrawInsetsFrameLayout;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -93,6 +94,7 @@ public class SettingsActivity extends AppCompatActivity
 
         if (getIntent() != null && getIntent().getCategories() != null &&
                 getIntent().getCategories().contains(Notification.INTENT_CATEGORY_NOTIFICATION_PREFERENCES)) {
+            FirebaseAnalytics.getInstance(this).logEvent("notification_preferences_open", null);
             mStartSection = START_SECTION_ADVANCED;
         }
 
@@ -222,6 +224,7 @@ public class SettingsActivity extends AppCompatActivity
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.action_get_more_sources:
+                        FirebaseAnalytics.getInstance(SettingsActivity.this).logEvent("more_sources_open", null);
                         try {
                             Intent playStoreIntent = new Intent(Intent.ACTION_VIEW,
                                     Uri.parse("http://play.google.com/store/search?q=Muzei&c=apps"))
@@ -236,6 +239,7 @@ public class SettingsActivity extends AppCompatActivity
                         return true;
 
                     case R.id.action_about:
+                        FirebaseAnalytics.getInstance(SettingsActivity.this).logEvent("about_open", null);
                         startActivity(new Intent(SettingsActivity.this, AboutActivity.class));
                         return true;
                 }

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
@@ -60,6 +60,7 @@ import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.android.apps.muzei.util.CheatSheet;
 import com.google.android.apps.muzei.util.ObservableHorizontalScrollView;
 import com.google.android.apps.muzei.util.Scrollbar;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -134,6 +135,10 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
         if (!(activity instanceof Callbacks)) {
             throw new ClassCastException("Activity must implement fragment callbacks.");
         }
+
+        Bundle bundle = new Bundle();
+        bundle.putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "sources");
+        FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.VIEW_ITEM_LIST, bundle);
     }
 
     @Override
@@ -460,9 +465,18 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
                     if (source.componentName.equals(mSelectedSource)) {
                         ((Callbacks) getActivity()).onRequestCloseActivity();
                     } else if (source.setupActivity != null) {
+                        Bundle bundle = new Bundle();
+                        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, source.componentName.flattenToShortString());
+                        bundle.putString(FirebaseAnalytics.Param.ITEM_NAME, source.label);
+                        bundle.putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "sources");
+                        FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.VIEW_ITEM, bundle);
                         mCurrentInitialSetupSource = source.componentName;
                         launchSourceSetup(source);
                     } else {
+                        Bundle bundle = new Bundle();
+                        bundle.putString(FirebaseAnalytics.Param.ITEM_ID, source.componentName.flattenToShortString());
+                        bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
+                        FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
                         mSourceManager.selectSource(source.componentName);
                     }
                 }
@@ -542,6 +556,10 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_EXTENSION_SETUP) {
             if (resultCode == Activity.RESULT_OK && mCurrentInitialSetupSource != null) {
+                Bundle bundle = new Bundle();
+                bundle.putString(FirebaseAnalytics.Param.ITEM_ID, mCurrentInitialSetupSource.flattenToShortString());
+                bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
+                FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
                 mSourceManager.selectSource(mCurrentInitialSetupSource);
             }
 

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -45,6 +45,8 @@ android {
 
         versionName versionProps['name']
         versionCode versionProps['codeWear'].toInteger()
+
+        buildConfigField "String", "DEVICE_TYPE", "\"wear\""
     }
 
     signingConfigs {

--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
 
     <uses-feature android:name="android.hardware.type.watch"/>
 
+    <!-- Used by Firebase Analytics -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <!-- Required to act as a custom watch face. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ActivateMuzeiIntentService.java
@@ -38,6 +38,7 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.CapabilityApi;
 import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.Wearable;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -88,8 +89,10 @@ public class ActivateMuzeiIntentService extends IntentService {
             if (PlayStoreAvailability.getPlayStoreAvailabilityOnPhone(context)
                     != PlayStoreAvailability.PLAY_STORE_ON_PHONE_AVAILABLE) {
                 builder.setContentText(context.getString(R.string.activate_no_play_store));
+                FirebaseAnalytics.getInstance(context).logEvent("activate_notif_no_play_store", null);
             } else {
                 builder.setContentText(context.getString(R.string.activate_install_muzei));
+                FirebaseAnalytics.getInstance(context).logEvent("activate_notif_play_store", null);
             }
             notificationManager.notify(NOTIFICATION_ID, builder.build());
             return;
@@ -114,6 +117,7 @@ public class ActivateMuzeiIntentService extends IntentService {
         builder.extend(new NotificationCompat.WearableExtender()
                 .setContentAction(0)
                 .setBackground(background));
+        FirebaseAnalytics.getInstance(context).logEvent("activate_notif_installed", null);
         notificationManager.notify(NOTIFICATION_ID, builder.build());
     }
 
@@ -146,6 +150,7 @@ public class ActivateMuzeiIntentService extends IntentService {
         if (nodes.isEmpty()) {
             Toast.makeText(this, R.string.activate_failed, Toast.LENGTH_SHORT).show();
         } else {
+            FirebaseAnalytics.getInstance(this).logEvent("activate_notif_message_sent", null);
             // Show the open on phone animation
             Intent openOnPhoneIntent = new Intent(this, ConfirmationActivity.class);
             openOnPhoneIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/wearable/src/main/java/com/google/android/apps/muzei/FullScreenActivity.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/FullScreenActivity.java
@@ -41,7 +41,9 @@ import com.google.android.apps.muzei.api.Artwork;
 import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.android.apps.muzei.util.PanView;
 import com.google.android.apps.muzei.util.TypefaceUtil;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
+import net.nurik.roman.muzei.BuildConfig;
 import net.nurik.roman.muzei.R;
 
 import java.io.FileNotFoundException;
@@ -66,6 +68,7 @@ public class FullScreenActivity extends Activity implements LoaderManager.Loader
     public void onCreate(Bundle savedState) {
         super.onCreate(savedState);
         setContentView(R.layout.full_screen_activity);
+        FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
         mPanView = (PanView) findViewById(R.id.pan_view);
         getLoaderManager().initLoader(0, null, this);
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -45,7 +45,9 @@ import android.view.WindowInsets;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.android.apps.muzei.util.ImageBlurrer;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
+import net.nurik.roman.muzei.BuildConfig;
 import net.nurik.roman.muzei.R;
 
 import java.io.FileNotFoundException;
@@ -79,6 +81,12 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
      * Update rate in milliseconds for mute mode. We update every minute, like in ambient mode.
      */
     private static final long MUTE_UPDATE_RATE_MS = TimeUnit.MINUTES.toMillis(1);
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
+    }
 
     @Override
     public Engine onCreateEngine() {

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -209,10 +209,8 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
 
         @Override
         public void onCreate(SurfaceHolder holder) {
-            if (Log.isLoggable(TAG, Log.DEBUG)) {
-                Log.d(TAG, "onCreate");
-            }
             super.onCreate(holder);
+            FirebaseAnalytics.getInstance(MuzeiWatchFace.this).logEvent("watchface_created", null);
 
             mMute = getInterruptionFilter() == WatchFaceService.INTERRUPTION_FILTER_NONE;
             SharedPreferences preferences =
@@ -300,6 +298,7 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
 
         @Override
         public void onDestroy() {
+            FirebaseAnalytics.getInstance(MuzeiWatchFace.this).logEvent("watchface_destroyed", null);
             mUpdateTimeHandler.removeMessages(MSG_UPDATE_TIME);
             super.onDestroy();
         }

--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
@@ -26,6 +26,7 @@ import android.support.wearable.complications.ComplicationManager;
 import android.support.wearable.complications.ComplicationProviderService;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -40,6 +41,7 @@ public class ArtworkComplicationProviderService extends ComplicationProviderServ
     @Override
     public void onComplicationActivated(int complicationId, int type, ComplicationManager manager) {
         addComplication(complicationId);
+        FirebaseAnalytics.getInstance(this).logEvent("complication_artwork_activated", null);
     }
 
     private void addComplication(int complicationId) {
@@ -54,6 +56,7 @@ public class ArtworkComplicationProviderService extends ComplicationProviderServ
 
     @Override
     public void onComplicationDeactivated(int complicationId) {
+        FirebaseAnalytics.getInstance(this).logEvent("complication_artwork_deactivated", null);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         Set<String> complications = preferences.getStringSet(KEY_COMPLICATION_IDS, new TreeSet<String>());
         complications.remove(Integer.toString(complicationId));

--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
@@ -28,6 +28,8 @@ import android.support.wearable.complications.ComplicationProviderService;
 import com.google.android.apps.muzei.api.MuzeiContract;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
+import net.nurik.roman.muzei.BuildConfig;
+
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -37,6 +39,12 @@ import java.util.TreeSet;
 @TargetApi(Build.VERSION_CODES.N)
 public class ArtworkComplicationProviderService extends ComplicationProviderService {
     static String KEY_COMPLICATION_IDS = "complication_ids";
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
+    }
 
     @Override
     public void onComplicationActivated(int complicationId, int type, ComplicationManager manager) {


### PR DESCRIPTION
Add analytics around the most important flows such as first time activation, wallpaper and watch face usage, etc.

Added user properties:
- `device_type` to filter Android vs Wear
- `selected_source` to filter analytics/crashes by the current source