### PR TITLE
Reduce number of APKs by using the universal binary for non ARM devices.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ ext {
     picassoVersion = "2.5.2"
 
     abiSplitMultiplier = 10000
-    abiSplitVersionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'mips':3, 'x86':4, 'x86_64':5]
+    abiSplitVersionCodes = ['armeabi-v7a':1, 'arm64-v8a':2]
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -71,7 +71,7 @@ android {
         abi {
             enable true
             reset()
-            include "armeabi-v7a", "arm64-v8a", "mips", "x86", "x86_64"
+            include "armeabi-v7a", "arm64-v8a"
             universalApk true
         }
     }


### PR DESCRIPTION
The number of mips and x86 devices is so low that it is not worth specifically supporting those devices with a split APK - the universal APK will allow those devices to continue to work at some expense of increased download size.