### PR TITLE
Ensure build type of embedded Wear apps match main app

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -146,8 +146,8 @@ dependencies {
     compile project(':android-client-common')
     compile project(':source-featured-art')
     compile project(':source-gallery')
-    devWearApp project(path: ':wearable', configuration: 'devRelease')
-    prodWearApp project(path: ':wearable', configuration: 'prodRelease')
+    releaseWearApp project(path: ':wearable', configuration: 'prodRelease')
+    publicBetaWearApp project(path: ':wearable', configuration: 'prodPublicBeta')
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
main release builds will include a wearable release build
main publicBeta builds will include a wearable publicbeta build