### PR TITLE
Fix crashes found in 2.3 Beta 1

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 
 name = 2.3
 # Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
-codeWear = 2300
+codeWear = 2302
 # Add one to codeWear to ensure a unique version code for the main app
-code = 2301
+code = 2303
 
 # Latest beta number for this version. Only applies to beta builds.
-betaNumber = Beta 1
+betaNumber = Beta 2

--- a/wearable/proguard-project.txt
+++ b/wearable/proguard-project.txt
@@ -26,3 +26,11 @@
 }
 
 -dontobfuscate
+
+# Renderscript support
+
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+-keep class android.support.v8.renderscript.** { *; }


### PR DESCRIPTION
Fix crash issues with Muzei 2.3 Beta 1 including
- Race conditions when apps were reading artwork as new artwork was being inserted
- Wear Renderscript/ProGuard issues
- Gallery crashing due to not correctly adding the `IS_TREE_URI` column

Also increments the version code in preparation for Beta 2