### PR TITLE
Integrate feedback from 2.3 Beta 3: Wearable edge cases

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 
 name = 2.3
 # Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
-codeWear = 2302
+codeWear = 2304
 # Add one to codeWear to ensure a unique version code for the main app
-code = 2303
+code = 2305
 
 # Latest beta number for this version. Only applies to beta builds.
-betaNumber = Beta 2
+betaNumber = Beta 3

--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
         <service
             android:name="com.google.android.apps.muzei.complications.ArtworkComplicationProviderService"
             android:label="@string/complication_artwork_label"
+            android:enabled="false"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />

--- a/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
@@ -89,6 +89,8 @@ public class ArtworkCacheIntentService extends IntentService {
         if (!foundArtwork && intent != null &&
                 intent.getBooleanExtra(SHOW_ACTIVATE_NOTIFICATION_EXTRA, false)) {
             ActivateMuzeiIntentService.maybeShowActivateMuzeiNotification(this);
+        } else {
+            ActivateMuzeiIntentService.clearNotifications(this);
         }
         googleApiClient.disconnect();
     }

--- a/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/ArtworkCacheIntentService.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import com.google.android.apps.muzei.api.Artwork;
 import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.android.apps.muzei.complications.ArtworkComplicationProviderService;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.Asset;
@@ -82,8 +83,8 @@ public class ArtworkCacheIntentService extends IntentService {
         }
         dataItemBuffer.release();
         if (foundArtwork) {
-            // Enable the Full Screen Activity only if we've found artwork
-            enableComponents(FullScreenActivity.class);
+            // Enable the Full Screen Activity and Artwork Complication Provider Service only if we've found artwork
+            enableComponents(FullScreenActivity.class, ArtworkComplicationProviderService.class);
         }
         if (!foundArtwork && intent != null &&
                 intent.getBooleanExtra(SHOW_ACTIVATE_NOTIFICATION_EXTRA, false)) {


### PR DESCRIPTION
Improve handling of activate/install Muzei notifications when Muzei Wear app is installed without the phone app and disable the complication provider until the first real image is available.

Also improves a long standing issue with example-contract-widget which was preventing testing of the API.