### PR TITLE
Ensure the ArtworkLoadingStateChangedEvent is fired

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkJobService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkJobService.java
@@ -30,6 +30,7 @@ public class DownloadArtworkJobService extends JobService {
         mDownloadArtworkTask = new DownloadArtworkTask(this) {
             @Override
             protected void onPostExecute(Boolean success) {
+                super.onPostExecute(success);
                 jobFinished(params, !success);
             }
         };


### PR DESCRIPTION
The DownloadArtworkJobService did not properly fire the ArtworkLoadingStateChangedEvent on completion due to a missing super call.