### PR TITLE
Fix crashes reported in 2.3 Beta 3

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiProvider.java
@@ -672,7 +672,8 @@ public class MuzeiProvider extends ContentProvider {
             return null;
         }
         if (!data.moveToFirst()) {
-            throw new IllegalStateException("Invalid URI: " + artworkUri);
+            Log.e(TAG, "Invalid artwork URI " + artworkUri);
+            return null;
         }
         // While normally we'd use data.getLong(), we later need this as a String so the automatic conversion helps here
         String id = data.getString(0);

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -80,7 +80,8 @@ public class MuzeiWallpaperService extends GLWallpaperService {
         // Ensure we retry loading the artwork if the network changed while the wallpaper was disabled
         ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
         Intent retryIntent = TaskQueueService.maybeRetryDownloadDueToGainedConnectivity(this);
-        if (retryIntent != null && connectivityManager.getActiveNetworkInfo().isConnected()) {
+        if (retryIntent != null && connectivityManager.getActiveNetworkInfo() != null &&
+                connectivityManager.getActiveNetworkInfo().isConnected()) {
             startService(retryIntent);
         }
 

--- a/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
@@ -86,6 +86,11 @@ public class NextArtworkTileService extends TileService {
 
     private void updateTile() {
         Tile tile = getQsTile();
+        if (tile == null) {
+            // We're outside of the onStartListening / onStopListening window
+            // We'll update the tile next time onStartListening is called.
+            return;
+        }
         if (!mWallpaperActive) {
             // If the wallpaper isn't active, the quick tile will activate it
             tile.setState(Tile.STATE_INACTIVE);

--- a/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
@@ -67,7 +67,9 @@ public class BitmapRegionLoader {
         if (mBitmapRegionDecoder != null) {
             mOriginalWidth = mBitmapRegionDecoder.getWidth();
             mOriginalHeight = mBitmapRegionDecoder.getHeight();
-            mValid = true;
+            if (mOriginalWidth > 0 && mOriginalHeight > 0) {
+                mValid = true;
+            }
         }
     }
 

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
@@ -117,6 +117,7 @@ public class MuzeiRendererFragment extends Fragment implements
                 ImageBlurrer blurrer = new ImageBlurrer(getActivity());
                 Bitmap blurred = blurrer.blurBitmap(bitmap,
                         ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0);
+                blurrer.destroy();
 
                 // Dim
                 Canvas c = new Canvas(blurred);

--- a/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
@@ -24,6 +24,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.provider.BaseColumns;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
@@ -75,7 +76,12 @@ public class DownloadArtworkTask extends AsyncTask<Void, Void, Boolean> {
         }
         Uri artworkUri = ContentUris.withAppendedId(MuzeiContract.Artwork.CONTENT_URI,
                 data.getLong(0));
-        Uri imageUri = Uri.parse(data.getString(1));
+        String imageUriString = data.getString(1);
+        if (TextUtils.isEmpty(imageUriString)) {
+            // There's nothing else we can do here so declare success
+            return true;
+        }
+        Uri imageUri = Uri.parse(imageUriString);
         data.close();
         OutputStream out = null;
         InputStream in = null;

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -989,7 +989,13 @@ public class GallerySettingsActivity extends AppCompatActivity
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            hideAddToolbar(true);
+            if (!mAddToolbar.isAttachedToWindow()) {
+                // Can't animate detached Views
+                mAddToolbar.setVisibility(View.INVISIBLE);
+                mAddButton.setVisibility(View.VISIBLE);
+            } else {
+                hideAddToolbar(true);
+            }
         }
 
         if (resultCode != RESULT_OK) {


### PR DESCRIPTION
Fixes a number of crashes reported in Muzei 2.3 Beta 3:
- Replaces IllegalStateException on loading artwork with null
- Destroys a no longer used ImageBlurrer
- Only allows BitmapRegionLoaders with a width/height > 0
- Don't crash when you have no active network when activating the wallpaper
- Don't load null artwork URIs
- Fix race condition on updating the quick settings tile
- Prevent Gallery from attempting to animate a detached view