### PR TITLE
Fix issues found in Muzei 2.3 Beta 4

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -25,6 +25,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.OperationApplicationException;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.RemoteException;
@@ -128,6 +129,13 @@ public class SourceManager {
             try {
                 ContentValues values = new ContentValues();
                 ComponentName source = ComponentName.unflattenFromString(pair[0]);
+                try {
+                    // Ensure the source is a valid Service
+                    mApplicationContext.getPackageManager().getServiceInfo(source, 0);
+                } catch (PackageManager.NameNotFoundException e) {
+                    // No need to keep no longer valid sources
+                    continue;
+                }
                 values.put(MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME, source.flattenToShortString());
                 values.put(MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED, source.equals(selectedSource));
                 JSONObject jsonObject = (JSONObject) new JSONTokener(pair[1]).nextValue();

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
@@ -514,7 +514,8 @@ public class GalleryProvider extends ContentProvider {
             return null;
         }
         if (!data.moveToFirst()) {
-            throw new IllegalStateException("Invalid URI: " + uri);
+            data.close();
+            throw new FileNotFoundException("Unable to load " + uri);
         }
         String imageUri = data.getString(0);
         data.close();
@@ -541,7 +542,8 @@ public class GalleryProvider extends ContentProvider {
                 return null;
             }
             if (!data.moveToFirst()) {
-                throw new IllegalStateException("Invalid URI: " + uri);
+                data.close();
+                return null;
             }
             imageUri = data.getString(0);
             data.close();


### PR DESCRIPTION
Fix crashes and edge cases exposed in Muzei 2.3 Beta 4
- Don't try to migrate data from no longer valid sources from SharedPreferences to MuzeiProvider
- Don't throw `IllegalStateException`s from GalleryProvider since callers are not prepared to handle runtime exceptions
- Catch `SecurityException`s generated by attempting to access no longer valid tree URIs in the Gallery. Now we just remove those URIs (as they are indeed no longer valid)