### PR TITLE
Re-add support for rotated images

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -18,13 +18,18 @@ package com.google.android.apps.muzei.render;
 
 import android.content.Context;
 import android.database.ContentObserver;
+import android.media.ExifInterface;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 public class RealRenderController extends RenderController {
     private static final String TAG = "RealRenderController";
@@ -57,11 +62,50 @@ public class RealRenderController extends RenderController {
     protected BitmapRegionLoader openDownloadedCurrentArtwork(boolean forceReload) {
         // Load the stream
         try {
+            // Check if there's rotation
+            int rotation = 0;
+            try {
+                InputStream in = mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI);
+                ExifInterface exifInterface;
+                if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    exifInterface = new ExifInterface(in);
+                } else {
+                    exifInterface = new ExifInterface(writeArtworkToFile(in).getAbsolutePath());
+                }
+                int orientation = exifInterface.getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+                switch (orientation) {
+                    case ExifInterface.ORIENTATION_ROTATE_90: rotation = 90; break;
+                    case ExifInterface.ORIENTATION_ROTATE_180: rotation = 180; break;
+                    case ExifInterface.ORIENTATION_ROTATE_270: rotation = 270; break;
+                }
+            } catch (IOException e) {
+                Log.w(TAG, "Couldn't open EXIF interface on artwork", e);
+            }
             return BitmapRegionLoader.newInstance(
-                    mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI), 0);
+                    mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI), rotation);
         } catch (IOException e) {
             Log.e(TAG, "Error loading image", e);
             return null;
         }
+    }
+
+    private File writeArtworkToFile(InputStream in) throws IOException {
+        File file = new File(mContext.getCacheDir(), "temp_artwork");
+        FileOutputStream out = new FileOutputStream(file);
+        try {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) > 0) {
+                out.write(buffer, 0, bytesRead);
+            }
+            out.flush();
+        } finally {
+            try {
+                out.close();
+            } catch (IOException ignored) {
+            }
+        }
+        return file;
     }
 }


### PR DESCRIPTION
Ensure Muzei wallpapers and Wear display images with the correct rotation based on Exif data.

Has the unfortunate side effect for requiring a temporary file prior to Android 7.0 due to ExifInterface only supporting files on earlier versions of Android, but the speed difference is neglibile.