### PR TITLE
Remove the SourceManager Singleton

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -91,8 +91,6 @@ public class MuzeiActivity extends AppCompatActivity {
 
     private static final String PREF_SEEN_TUTORIAL = "seen_tutorial";
 
-    // Controller/logic fields
-    private SourceManager mSourceManager;
     private int mCurrentViewportId = 0;
     private float mWallpaperAspectRatio;
     private float mArtworkAspectRatio;
@@ -281,8 +279,6 @@ public class MuzeiActivity extends AppCompatActivity {
         });
 
         showHideChrome(true);
-
-        mSourceManager = SourceManager.getInstance(this);
 
         EventBus.getDefault().register(this);
 
@@ -621,7 +617,8 @@ public class MuzeiActivity extends AppCompatActivity {
         mNextButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mSourceManager.sendAction(MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
+                SourceManager.sendAction(MuzeiActivity.this,
+                        MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
                 mNextFakeLoading = true;
                 showNextFakeLoading();
             }
@@ -693,7 +690,7 @@ public class MuzeiActivity extends AppCompatActivity {
             public boolean onMenuItemClick(MenuItem menuItem) {
                 int id = mOverflowSourceActionMap.get(menuItem.getItemId());
                 if (id > 0) {
-                    mSourceManager.sendAction(id);
+                    SourceManager.sendAction(MuzeiActivity.this, id);
                     return true;
                 }
 

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -73,7 +73,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
         FirebaseAnalytics.getInstance(this).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
         mLockScreenVisibleReceiver = new LockScreenVisibleReceiver();
         mLockScreenVisibleReceiver.setupRegisterDeregister(this);
-        SourceManager.getInstance(MuzeiWallpaperService.this).subscribeToSelectedSource();
+        SourceManager.subscribeToSelectedSource(MuzeiWallpaperService.this);
         mNetworkChangeReceiver = new NetworkChangeReceiver();
         IntentFilter networkChangeFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
         registerReceiver(mNetworkChangeReceiver, networkChangeFilter);
@@ -141,7 +141,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
             unregisterReceiver(mNetworkChangeReceiver);
             mNetworkChangeReceiver = null;
         }
-        SourceManager.getInstance(MuzeiWallpaperService.this).unsubscribeToSelectedSource();
+        SourceManager.unsubscribeToSelectedSource(MuzeiWallpaperService.this);
         if (mLockScreenVisibleReceiver != null) {
             mLockScreenVisibleReceiver.destroy();
             mLockScreenVisibleReceiver = null;

--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -79,8 +79,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
             if (ACTION_MARK_NOTIFICATION_READ.equals(action)) {
                 markNotificationRead(context);
             } else if (ACTION_NEXT_ARTWORK.equals(action)) {
-                SourceManager sm = SourceManager.getInstance(context);
-                sm.sendAction(MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
+                SourceManager.sendAction(context, MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
             } else if (ACTION_USER_COMMAND.equals(action)) {
                 triggerUserCommandFromRemoteInput(context, intent);
             }
@@ -93,7 +92,6 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
             return;
         }
         String selectedCommand = remoteInput.getCharSequence(EXTRA_USER_COMMAND).toString();
-        SourceManager sm = SourceManager.getInstance(context);
         Cursor selectedSource = context.getContentResolver().query(MuzeiContract.Sources.CONTENT_URI,
                 new String[]{MuzeiContract.Sources.COLUMN_NAME_COMMANDS},
                 MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED + "=1", null, null, null);
@@ -101,7 +99,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
             List<UserCommand> commands = MuzeiContract.Sources.parseCommands(selectedSource.getString(0));
             for (UserCommand action : commands) {
                 if (TextUtils.equals(selectedCommand, action.getTitle())) {
-                    sm.sendAction(action.getId());
+                    SourceManager.sendAction(context, action.getId());
                     break;
                 }
             }

--- a/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
@@ -44,8 +44,7 @@ public class PhotoSetAsTargetActivity extends Activity {
                 new ComponentName(this, GalleryArtSource.class).flattenToShortString());
         bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
         FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
-        SourceManager sourceManager = SourceManager.getInstance(this);
-        sourceManager.selectSource(new ComponentName(this, GalleryArtSource.class));
+        SourceManager.selectSource(this, new ComponentName(this, GalleryArtSource.class));
 
         // Add and publish the chosen photo
         ContentValues values = new ContentValues();

--- a/main/src/main/java/com/google/android/apps/muzei/SourcePackageChangeReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourcePackageChangeReceiver.java
@@ -24,6 +24,8 @@ import android.support.v4.content.WakefulBroadcastReceiver;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.google.android.apps.muzei.featuredart.FeaturedArtSource;
+
 /**
  * Broadcast receiver used to watch for changes to installed packages on the device. This triggers
  * a cleanup of sources (in case one was uninstalled), or a data update request to a source
@@ -39,9 +41,9 @@ public class SourcePackageChangeReceiver extends WakefulBroadcastReceiver {
         }
 
         String packageName = intent.getData().getSchemeSpecificPart();
-        SourceManager sourceManager = SourceManager.getInstance(context);
-        ComponentName selectedComponent = sourceManager.getSelectedSource();
-        if (!TextUtils.equals(packageName, selectedComponent.getPackageName())) {
+        ComponentName selectedComponent = SourceManager.getSelectedSource(context);
+        if (selectedComponent == null ||
+                !TextUtils.equals(packageName, selectedComponent.getPackageName())) {
             return;
         }
 
@@ -49,12 +51,13 @@ public class SourcePackageChangeReceiver extends WakefulBroadcastReceiver {
             context.getPackageManager().getServiceInfo(selectedComponent, 0);
         } catch (PackageManager.NameNotFoundException e) {
             Log.i(TAG, "Selected source no longer available; switching to default.");
-            sourceManager.selectDefaultSource();
+            SourceManager.selectSource(context,
+                    new ComponentName(context, FeaturedArtSource.class));
             return;
         }
 
         // Some other change.
         Log.i(TAG, "Source package changed or replaced. Re-subscribing.");
-        sourceManager.subscribeToSelectedSource();
+        SourceManager.subscribeToSelectedSource(context);
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
@@ -61,7 +61,7 @@ public class SourceSubscriberService extends IntentService {
         }
         // Handle API call from source
         String token = intent.getStringExtra(EXTRA_TOKEN);
-        ComponentName selectedSource = SourceManager.getInstance(this).getSelectedSource();
+        ComponentName selectedSource = SourceManager.getSelectedSource(this);
         if (selectedSource == null ||
                 !TextUtils.equals(token, selectedSource.flattenToShortString())) {
             Log.w(TAG, "Dropping update from non-selected source.");

--- a/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
@@ -17,16 +17,34 @@
 package com.google.android.apps.muzei;
 
 import android.app.IntentService;
+import android.content.ComponentName;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
 import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Bundle;
+import android.provider.BaseColumns;
+import android.text.TextUtils;
+import android.util.Log;
 
+import com.google.android.apps.muzei.api.Artwork;
+import com.google.android.apps.muzei.api.MuzeiArtSource;
+import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.android.apps.muzei.api.UserCommand;
 import com.google.android.apps.muzei.api.internal.SourceState;
+import com.google.android.apps.muzei.sync.TaskQueueService;
 
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.ACTION_PUBLISH_STATE;
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.EXTRA_STATE;
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.EXTRA_TOKEN;
 
+import org.json.JSONArray;
+
 public class SourceSubscriberService extends IntentService {
+    private static final String TAG = "SourceSubscriberService";
+
     public SourceSubscriberService() {
         super("SourceSubscriberService");
     }
@@ -38,19 +56,72 @@ public class SourceSubscriberService extends IntentService {
         }
 
         String action = intent.getAction();
-        if (ACTION_PUBLISH_STATE.equals(action)) {
-            // Handle API call from source
-            String token = intent.getStringExtra(EXTRA_TOKEN);
+        if (!ACTION_PUBLISH_STATE.equals(action)) {
+            return;
+        }
+        // Handle API call from source
+        String token = intent.getStringExtra(EXTRA_TOKEN);
+        ComponentName selectedSource = SourceManager.getInstance(this).getSelectedSource();
+        if (selectedSource == null ||
+                !TextUtils.equals(token, selectedSource.flattenToShortString())) {
+            Log.w(TAG, "Dropping update from non-selected source.");
+            return;
+        }
 
-            SourceState state = null;
-            if (intent.hasExtra(EXTRA_STATE)) {
-                Bundle bundle = intent.getBundleExtra(EXTRA_STATE);
-                if (bundle != null) {
-                    state = SourceState.fromBundle(bundle);
-                }
+        SourceState state = null;
+        if (intent.hasExtra(EXTRA_STATE)) {
+            Bundle bundle = intent.getBundleExtra(EXTRA_STATE);
+            if (bundle != null) {
+                state = SourceState.fromBundle(bundle);
             }
+        }
 
-            SourceManager.getInstance(this).handlePublishState(token, state);
+        if (state == null) {
+            // If there is no state, there is nothing to change
+            return;
+        }
+
+        ContentValues values = new ContentValues();
+        values.put(MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME, selectedSource.flattenToShortString());
+        values.put(MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED, true);
+        values.put(MuzeiContract.Sources.COLUMN_NAME_DESCRIPTION, state.getDescription());
+        values.put(MuzeiContract.Sources.COLUMN_NAME_WANTS_NETWORK_AVAILABLE, state.getWantsNetworkAvailable());
+        JSONArray commandsSerialized = new JSONArray();
+        int numSourceActions = state.getNumUserCommands();
+        boolean supportsNextArtwork = false;
+        for (int i = 0; i < numSourceActions; i++) {
+            UserCommand command = state.getUserCommandAt(i);
+            if (command.getId() == MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK) {
+                supportsNextArtwork = true;
+            } else {
+                commandsSerialized.put(command.serialize());
+            }
+        }
+        values.put(MuzeiContract.Sources.COLUMN_NAME_SUPPORTS_NEXT_ARTWORK_COMMAND, supportsNextArtwork);
+        values.put(MuzeiContract.Sources.COLUMN_NAME_COMMANDS, commandsSerialized.toString());
+        ContentResolver contentResolver = getContentResolver();
+        Cursor existingSource = contentResolver.query(MuzeiContract.Sources.CONTENT_URI,
+                new String[]{BaseColumns._ID},
+                MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME + "=?",
+                new String[] {selectedSource.flattenToShortString()}, null, null);
+        if (existingSource != null && existingSource.moveToFirst()) {
+            Uri sourceUri = ContentUris.withAppendedId(MuzeiContract.Sources.CONTENT_URI,
+                    existingSource.getLong(0));
+            contentResolver.update(sourceUri, values, null, null);
+        } else {
+            contentResolver.insert(MuzeiContract.Sources.CONTENT_URI, values);
+        }
+        if (existingSource != null) {
+            existingSource.close();
+        }
+
+        Artwork artwork = state.getCurrentArtwork();
+        if (artwork != null) {
+            artwork.setComponentName(selectedSource);
+            contentResolver.insert(MuzeiContract.Artwork.CONTENT_URI, artwork.toContentValues());
+
+            // Download the artwork contained from the newly published SourceState
+            startService(TaskQueueService.getDownloadCurrentArtworkIntent(this));
         }
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/quicksettings/NextArtworkTileService.java
@@ -130,7 +130,7 @@ public class NextArtworkTileService extends TileService {
             FirebaseAnalytics.getInstance(NextArtworkTileService.this).logEvent(
                     "tile_next_artwork_click", null);
             // Active means we send the 'Next Artwork' command
-            SourceManager.getInstance(this).sendAction(MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
+            SourceManager.sendAction(this, MuzeiArtSource.BUILTIN_COMMAND_ID_NEXT_ARTWORK);
         } else {
             // Inactive means we attempt to activate Muzei
             unlockAndRun(new Runnable() {

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
@@ -85,7 +85,6 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
 
     private static final int REQUEST_EXTENSION_SETUP = 1;
 
-    private SourceManager mSourceManager;
     private ComponentName mSelectedSource;
     private List<Source> mSources = new ArrayList<>();
 
@@ -123,8 +122,6 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
                 R.dimen.settings_choose_source_item_estimated_height);
         mItemImageSize = getResources().getDimensionPixelSize(
                 R.dimen.settings_choose_source_item_image_size);
-
-        mSourceManager = SourceManager.getInstance(getActivity());
 
         prepareGenerateSourceImages();
     }
@@ -269,7 +266,7 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
 
     private void updateSelectedItem(boolean allowAnimate) {
         ComponentName previousSelectedSource = mSelectedSource;
-        mSelectedSource = mSourceManager.getSelectedSource();
+        mSelectedSource = SourceManager.getSelectedSource(getContext());
         if (previousSelectedSource != null && previousSelectedSource.equals(mSelectedSource)) {
             // Only update status
             for (final Source source : mSources) {
@@ -477,7 +474,7 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
                         bundle.putString(FirebaseAnalytics.Param.ITEM_ID, source.componentName.flattenToShortString());
                         bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
                         FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
-                        mSourceManager.selectSource(source.componentName);
+                        SourceManager.selectSource(getContext(), source.componentName);
                     }
                 }
             });
@@ -560,7 +557,7 @@ public class SettingsChooseSourceFragment extends Fragment implements LoaderMana
                 bundle.putString(FirebaseAnalytics.Param.ITEM_ID, mCurrentInitialSetupSource.flattenToShortString());
                 bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
                 FirebaseAnalytics.getInstance(getActivity()).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
-                mSourceManager.selectSource(mCurrentInitialSetupSource);
+                SourceManager.selectSource(getContext(), mCurrentInitialSetupSource);
             }
 
             mCurrentInitialSetupSource = null;


### PR DESCRIPTION
Instead of having a SourceManager singleton managing some shared state, replace it with just a few static methods that get their information from the source of truth: the Sources table in the MuzeiProvider.

This also ensures that we don't have a singleton referencing the application context (which causes issues with Instant Run).