### PR TITLE
Fix 2.3 beta 4 crashes part 2

### DIFF
--- a/api/src/main/java/com/google/android/apps/muzei/api/internal/SourceState.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/internal/SourceState.java
@@ -70,7 +70,7 @@ public class SourceState {
         mWantsNetworkAvailable = wantsNetworkAvailable;
     }
 
-    public void setUserCommands(int... userCommands) {
+    public synchronized void setUserCommands(int... userCommands) {
         mUserCommands.clear();
         if (userCommands != null) {
             mUserCommands.ensureCapacity(userCommands.length);
@@ -80,7 +80,7 @@ public class SourceState {
         }
     }
 
-    public void setUserCommands(UserCommand... userCommands) {
+    public synchronized void setUserCommands(UserCommand... userCommands) {
         mUserCommands.clear();
         if (userCommands != null) {
             mUserCommands.ensureCapacity(userCommands.length);
@@ -88,14 +88,14 @@ public class SourceState {
         }
     }
 
-    public void setUserCommands(List<UserCommand> userCommands) {
+    public synchronized void setUserCommands(List<UserCommand> userCommands) {
         mUserCommands.clear();
         if (userCommands != null) {
             mUserCommands.addAll(userCommands);
         }
     }
 
-    public Bundle toBundle() {
+    public synchronized Bundle toBundle() {
         Bundle bundle = new Bundle();
         if (mCurrentArtwork != null) {
             bundle.putBundle("currentArtwork", mCurrentArtwork.toBundle());
@@ -128,7 +128,7 @@ public class SourceState {
         return state;
     }
 
-    public JSONObject toJson() throws JSONException{
+    public synchronized JSONObject toJson() throws JSONException{
         JSONObject jsonObject = new JSONObject();
         if (mCurrentArtwork != null) {
             jsonObject.put("currentArtwork", mCurrentArtwork.toJson());

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -156,7 +156,7 @@ public class SourceManager {
         operations.add(ContentProviderOperation.newUpdate(MuzeiContract.Sources.CONTENT_URI)
                 .withValue(MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME,
                         source.flattenToShortString())
-                .withValue(MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED, false)
+                .withValue(MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED, true)
                 .withSelection(MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME + "=?",
                         new String[] {source.flattenToShortString()})
                 .build());

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -57,6 +57,7 @@ public class SourceManager {
     private static final String PREF_SELECTED_SOURCE = "selected_source";
     private static final String PREF_SOURCE_STATES = "source_states";
     private static final String USER_PROPERTY_SELECTED_SOURCE = "selected_source";
+    private static final String USER_PROPERTY_SELECTED_SOURCE_PACKAGE = "selected_source_package";
 
     private SourceManager() {
     }
@@ -116,8 +117,7 @@ public class SourceManager {
         try {
             context.getContentResolver().applyBatch(MuzeiContract.AUTHORITY, operations);
             sharedPrefs.edit().remove(PREF_SELECTED_SOURCE).remove(PREF_SOURCE_STATES).apply();
-            FirebaseAnalytics.getInstance(context).setUserProperty(USER_PROPERTY_SELECTED_SOURCE,
-                    selectedSource.flattenToShortString());
+            sendSelectedSourceAnalytics(context, selectedSource);
         } catch (RemoteException | OperationApplicationException e) {
             Log.e(TAG, "Error writing sources to ContentProvider", e);
         }
@@ -163,8 +163,7 @@ public class SourceManager {
 
         try {
             context.getContentResolver().applyBatch(MuzeiContract.AUTHORITY, operations);
-            FirebaseAnalytics.getInstance(context).setUserProperty(USER_PROPERTY_SELECTED_SOURCE,
-                    source.flattenToShortString());
+            sendSelectedSourceAnalytics(context, source);
         } catch (RemoteException | OperationApplicationException e) {
             Log.e(TAG, "Error writing sources to ContentProvider", e);
         }
@@ -173,6 +172,24 @@ public class SourceManager {
 
         // Ensure the artwork from the newly selected source is downloaded
         context.startService(TaskQueueService.getDownloadCurrentArtworkIntent(context));
+    }
+
+    private static void sendSelectedSourceAnalytics(Context context, ComponentName selectedSource) {
+        // The current limit for user property values
+        final int MAX_VALUE_LENGTH = 36;
+        String packageName = selectedSource.getPackageName();
+        if (packageName.length() > MAX_VALUE_LENGTH) {
+            packageName = packageName.substring(packageName.length() - MAX_VALUE_LENGTH);
+        }
+        FirebaseAnalytics.getInstance(context).setUserProperty(USER_PROPERTY_SELECTED_SOURCE_PACKAGE,
+                packageName);
+        String className = selectedSource.flattenToShortString();
+        className = className.substring(className.indexOf('/')+1);
+        if (className.length() > MAX_VALUE_LENGTH) {
+            className = className.substring(className.length() - MAX_VALUE_LENGTH);
+        }
+        FirebaseAnalytics.getInstance(context).setUserProperty(USER_PROPERTY_SELECTED_SOURCE,
+                className);
     }
 
     public static ComponentName getSelectedSource(Context context) {

--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -66,6 +66,9 @@ public class RealRenderController extends RenderController {
             int rotation = 0;
             try {
                 InputStream in = mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI);
+                if (in == null) {
+                    return null;
+                }
                 ExifInterface exifInterface;
                 if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     exifInterface = new ExifInterface(in);

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
@@ -197,6 +197,10 @@ public class GalleryArtSource extends MuzeiArtSource {
                 }
             }
             int numImages = allImages.size();
+            if (numImages == 0) {
+                Log.e(TAG, "No photos in the selected directories.");
+                return;
+            }
             while (true) {
                 imageUri = allImages.get(random.nextInt(numImages));
                 if (numImages <= 1 || !imageUri.toString().equals(lastToken)) {


### PR DESCRIPTION
Fixes a number of issues
- User property value lengths (actually need to be capped at 36 characters)
- Properly selecting sources
- ExifInterface crashes
- Empty directories for the Gallery extension
- Synchronization issues with SourceState