### PR TITLE
Disable Firebase Crash Reporting on Dev Builds

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -134,7 +134,9 @@ dependencies {
     compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
     compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
     compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-core:$rootProject.ext.googlePlayServicesVersion"
+    // Only use crash reporting in the "prod" product flavor
+    prodCompile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
     compile "org.greenrobot:eventbus:3.0.0"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"


### PR DESCRIPTION
To prevent cluttering the Firebase Console with crashes for development builds, move the firebase-crash dependency to the "prod" product flavor. This allows us to still build prodDebug builds to test firebase-crash, but allows developers to continue to use devDebug and not bother others with crashes.