### PR TITLE
Remove unnecessary API version checks

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -665,13 +665,10 @@ public class MuzeiActivity extends AppCompatActivity {
         });
     }
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     private void setupOverflowButton() {
         final View overflowButton = findViewById(R.id.overflow_button);
         mOverflowMenu = new PopupMenu(this, overflowButton);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            overflowButton.setOnTouchListener(mOverflowMenu.getDragToOpenListener());
-        }
+        overflowButton.setOnTouchListener(mOverflowMenu.getDragToOpenListener());
         overflowButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -728,15 +725,13 @@ public class MuzeiActivity extends AppCompatActivity {
 
     private void showHideChrome(boolean show) {
         int flags = show ? 0 : View.SYSTEM_UI_FLAG_LOW_PROFILE;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            flags |= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
-            if (!show) {
-                flags |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_IMMERSIVE;
-            }
+        flags |= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
+        if (!show) {
+            flags |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_FULLSCREEN
+                    | View.SYSTEM_UI_FLAG_IMMERSIVE;
         }
         mContainerView.setSystemUiVisibility(flags);
     }

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
@@ -111,17 +111,10 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
         recomputeGreyAmount();
     }
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     private int getNumberOfKeyframes() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            ActivityManager activityManager = (ActivityManager)
-                    mContext.getSystemService(Context.ACTIVITY_SERVICE);
-            if (activityManager.isLowRamDevice()) {
-                return 1;
-            }
-        }
-
-        return 5;
+        ActivityManager activityManager = (ActivityManager)
+                mContext.getSystemService(Context.ACTIVITY_SERVICE);
+        return activityManager.isLowRamDevice() ? 1 : 5;
     }
 
     public void recomputeMaxPrescaledBlurPixels() {

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
@@ -71,19 +71,12 @@ public class MuzeiRendererFragment extends Fragment implements
     }
 
     @Override
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        boolean simpleDemoMode = false;
-        if (mDemoMode && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            ActivityManager activityManager = (ActivityManager)
-                    getActivity().getSystemService(Context.ACTIVITY_SERVICE);
-            if (activityManager.isLowRamDevice()) {
-                simpleDemoMode = true;
-            }
-        }
+        ActivityManager activityManager = (ActivityManager)
+                getActivity().getSystemService(Context.ACTIVITY_SERVICE);
 
-        if (simpleDemoMode) {
+        if (mDemoMode && activityManager.isLowRamDevice()) {
             DisplayMetrics dm = getResources().getDisplayMetrics();
             int targetWidth = dm.widthPixels;
             int targetHeight = dm.heightPixels;

--- a/main/src/main/java/com/google/android/apps/muzei/util/PanScaleProxyView.java
+++ b/main/src/main/java/com/google/android/apps/muzei/util/PanScaleProxyView.java
@@ -80,7 +80,7 @@ public class PanScaleProxyView extends View {
 
         // Sets up interactions
         mScaleGestureDetector = new ScaleGestureDetector(context, mScaleGestureListener);
-        ScaleGestureDetectorCompat.setQuickScaleEnabled(mScaleGestureDetector, true);
+        mScaleGestureDetector.setQuickScaleEnabled(true);
         mGestureDetector = new GestureDetectorCompat(context, mGestureListener);
 
         mScroller = new OverScroller(context);
@@ -264,7 +264,7 @@ public class PanScaleProxyView extends View {
             // Workaround for 11952668; blow away the entire scale gesture detector after
             // a double tap
             mScaleGestureDetector = new ScaleGestureDetector(getContext(), mScaleGestureListener);
-            ScaleGestureDetectorCompat.setQuickScaleEnabled(mScaleGestureDetector, true);
+            mScaleGestureDetector.setQuickScaleEnabled(true);
             return true;
         }
 

--- a/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
@@ -52,8 +52,7 @@ public class WearableController {
     private static final String TAG = "WearableController";
 
     public static synchronized void updateArtwork(Context context) {
-        if (ConnectionResult.SUCCESS != GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
-                || Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        if (ConnectionResult.SUCCESS != GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)) {
             return;
         }
         GoogleApiClient googleApiClient = new GoogleApiClient.Builder(context)


### PR DESCRIPTION
Now that the minSdkVersion of Muzei is KitKat, we can remove compat calls and version checks that no longer apply