### PR TITLE
Add initial support for Direct Boot

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     compile project(':api')
-    compile "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
+    compile "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
 }
 
 android {

--- a/android-client-common/src/main/AndroidManifest.xml
+++ b/android-client-common/src/main/AndroidManifest.xml
@@ -24,10 +24,15 @@
         <provider
             android:name="com.google.android.apps.muzei.provider.MuzeiProvider"
             android:authorities="com.google.android.apps.muzei"
+            android:directBootAware="true"
             android:exported="true"
             android:writePermission="com.google.android.apps.muzei.WRITE_PROVIDER">
             <grant-uri-permission android:pathPattern=".*"/>
         </provider>
+        <service
+            android:name="com.google.android.apps.muzei.provider.DirectBootCacheJobService"
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
         <provider
             android:name="com.google.android.apps.muzei.provider.MuzeiDocumentsProvider"
             android:authorities="com.google.android.apps.muzei.documents"

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/DirectBootCacheJobService.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/DirectBootCacheJobService.java
@@ -1,0 +1,92 @@
+package com.google.android.apps.muzei.provider;
+
+import android.annotation.TargetApi;
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
+
+import com.google.android.apps.muzei.api.MuzeiContract;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Update the latest artwork in the Direct Boot cache directory whenever the artwork changes
+ */
+@TargetApi(Build.VERSION_CODES.N)
+public class DirectBootCacheJobService extends JobService {
+    private static final String TAG = "DirectBootCacheJS";
+    private static final int DIRECT_BOOT_CACHE_JOB_ID = 68;
+    private static final String DIRECT_BOOT_CACHE_FILENAME = "current";
+
+    private AsyncTask<Void, Void, Boolean> mCacheTask = null;
+
+    static void scheduleDirectBootCacheJob(Context context) {
+        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        ComponentName componentName = new ComponentName(context, DirectBootCacheJobService.class);
+        jobScheduler.schedule(new JobInfo.Builder(DIRECT_BOOT_CACHE_JOB_ID, componentName)
+                .addTriggerContentUri(new JobInfo.TriggerContentUri(
+                        MuzeiContract.Artwork.CONTENT_URI,
+                        JobInfo.TriggerContentUri.FLAG_NOTIFY_FOR_DESCENDANTS))
+                .build());
+    }
+
+    static File getCachedArtwork(Context context) {
+        Context directBootContext = ContextCompat.createDeviceProtectedStorageContext(context);
+        return directBootContext == null
+                ? null
+                : new File(directBootContext.getCacheDir(), DIRECT_BOOT_CACHE_FILENAME);
+    }
+
+    @Override
+    public boolean onStartJob(final JobParameters params) {
+        mCacheTask = new AsyncTask<Void, Void, Boolean>() {
+            @Override
+            protected Boolean doInBackground(Void... voids) {
+                File artwork = getCachedArtwork(DirectBootCacheJobService.this);
+                if (artwork == null) {
+                    return false;
+                }
+                try (InputStream in = getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI);
+                     FileOutputStream out = new FileOutputStream(artwork)) {
+                    if (in == null) {
+                        return false;
+                    }
+                    byte[] buffer = new byte[1024];
+                    int read;
+                    while((read = in.read(buffer)) != -1){
+                        out.write(buffer, 0, read);
+                    }
+                    return true;
+                } catch (IOException e) {
+                    Log.e(TAG, "Unable to write artwork to direct boot storage", e);
+                }
+                return false;
+            }
+
+            @Override
+            protected void onPostExecute(Boolean success) {
+                jobFinished(params, !success);
+            }
+        };
+        mCacheTask.execute();
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        if (mCacheTask != null) {
+            mCacheTask.cancel(true);
+        }
+        return true;
+    }
+}

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
 
         <service
             android:name="com.google.android.apps.muzei.MuzeiWallpaperService"
+            android:directBootAware="true"
             android:permission="android.permission.BIND_WALLPAPER">
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />

--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -47,9 +47,7 @@ public class RealRenderController extends RenderController {
         };
         context.getContentResolver().registerContentObserver(MuzeiContract.Artwork.CONTENT_URI,
                 true, mContentObserver);
-        if (MuzeiContract.Artwork.getCurrentArtwork(context) != null) {
-            reloadCurrentArtwork(false);
-        }
+        reloadCurrentArtwork(false);
     }
 
     @Override


### PR DESCRIPTION
Allows Muzei wallpapers to appear while the device is in Direct Boot mode (i.e., before the user has unlocked the device).

Currently this does not take into account user preferences for blurring, dimming, or lock screen specific behavior.

It also assumes that only reading the image is done while in Direct Boot mode. No support for inserts, updates, deletes, or queries until the user is unlocked.