### PR TITLE
Switch to framework Renderscript

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -37,8 +37,6 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion rootProject.ext.targetSdkVersion
-        renderscriptTargetApi rootProject.ext.targetSdkVersion
-        renderscriptSupportModeEnabled true
     }
 
     compileOptions {

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
@@ -18,12 +18,12 @@ package com.google.android.apps.muzei.util;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.support.v8.renderscript.Allocation;
-import android.support.v8.renderscript.Element;
-import android.support.v8.renderscript.Matrix3f;
-import android.support.v8.renderscript.RenderScript;
-import android.support.v8.renderscript.ScriptIntrinsicBlur;
-import android.support.v8.renderscript.ScriptIntrinsicColorMatrix;
+import android.renderscript.Allocation;
+import android.renderscript.Element;
+import android.renderscript.Matrix3f;
+import android.renderscript.RenderScript;
+import android.renderscript.ScriptIntrinsicBlur;
+import android.renderscript.ScriptIntrinsicColorMatrix;
 
 public class ImageBlurrer {
     public static final int MAX_SUPPORTED_BLUR_PIXELS = 25;

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,4 @@ ext {
     googlePlayServicesVersion = "10.0.1"
     okhttpVersion = "3.5.0"
     picassoVersion = "2.5.2"
-
-    abiSplitMultiplier = 10000
-    abiSplitVersionCodes = ['armeabi-v7a':1, 'arm64-v8a':2]
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -43,8 +43,6 @@ android {
         applicationId "net.nurik.roman.muzei"
         minSdkVersion 19
         targetSdkVersion rootProject.ext.targetSdkVersion
-        renderscriptTargetApi rootProject.ext.targetSdkVersion
-        renderscriptSupportModeEnabled true
 
         versionName versionProps['name']
         versionCode versionProps['code'].toInteger()
@@ -64,25 +62,6 @@ android {
             keyAlias keyProps["alias"] ?: ""
             storePassword keyProps["storePass"] ?: ""
             keyPassword keyProps["pass"] ?: ""
-        }
-    }
-
-    splits {
-        abi {
-            enable true
-            reset()
-            include "armeabi-v7a", "arm64-v8a"
-            universalApk true
-        }
-    }
-
-    // For each APK output variant, add in the ABI specific versionCode
-    applicationVariants.all { variant ->
-        // assign different version code for each output
-        variant.outputs.each { output ->
-            int abiVersionCode = rootProject.ext.abiSplitVersionCodes.get(
-                    output.getFilter(com.android.build.OutputFile.ABI)) ?: 0
-            output.versionCodeOverride = abiVersionCode * rootProject.ext.abiSplitMultiplier + defaultConfig.versionCode
         }
     }
 

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -34,11 +34,3 @@
 # okio
 
 -dontwarn okio.**
-
-# Renderscript support
-
--keepclasseswithmembernames class * {
-    native <methods>;
-}
-
--keep class android.support.v8.renderscript.** { *; }

--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 
 name = 2.3
 # Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
-codeWear = 2308
+codeWear = 23008
 # Add one to codeWear to ensure a unique version code for the main app
-code = 2309
+code = 23009
 
 # Latest beta number for this version. Only applies to beta builds.
 betaNumber = Beta 5

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -39,9 +39,6 @@ android {
         applicationId "net.nurik.roman.muzei"
         minSdkVersion 23
         targetSdkVersion rootProject.ext.targetSdkVersion
-        renderscriptTargetApi rootProject.ext.targetSdkVersion
-        renderscriptSupportModeEnabled true
-        ndk.abiFilters 'armeabi-v7a', 'x86'
 
         versionName versionProps['name']
         versionCode versionProps['codeWear'].toInteger()

--- a/wearable/proguard-project.txt
+++ b/wearable/proguard-project.txt
@@ -26,11 +26,3 @@
 }
 
 -dontobfuscate
-
-# Renderscript support
-
--keepclasseswithmembernames class * {
-    native <methods>;
-}
-
--keep class android.support.v8.renderscript.** { *; }


### PR DESCRIPTION
Since increasing the minSdkVersion, we can now use the framework Renderscript. This should ensure better compatibility, less crashes, and also gives us a much smaller overall APK since we no longer need the Renderscript Support Library's native libraries.

Removed ABI split code as it is no longer necessary.