### PR TITLE
Fix MuzeiRendererFragment crash on low memory devices

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/util/ImageBlurrer.java
@@ -46,7 +46,7 @@ public class ImageBlurrer {
             return null;
         }
 
-        Bitmap dest = src.copy(src.getConfig(), false);
+        Bitmap dest = src.copy(src.getConfig(), true);
         if (radius == 0f && desaturateAmount == 0f) {
             return dest;
         }


### PR DESCRIPTION
Exception java.lang.IllegalStateException: Immutable bitmap passed to Canvas constructor
android.graphics.Canvas.<init> (Canvas.java:150)
com.google.android.apps.muzei.render.MuzeiRendererFragment$1.onBitmapLoaded (MuzeiRendererFragment.java:116)

Caused by creating an immutable Bitmap when blurring. Turns out, there's no benefit from making the Bitmap immutable so making it mutable fixes the problem.