### PR TITLE
Fix GallerySettingsCrash when attempting animation of a detached view

### DIFF
--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -884,6 +884,12 @@ public class GallerySettingsActivity extends AppCompatActivity
                     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
                     @Override
                     public void run() {
+                        if (!vh.mCheckedOverlayView.isAttachedToWindow()) {
+                            // Can't animate detached Views
+                            vh.mCheckedOverlayView.setVisibility(
+                                    checked ? View.VISIBLE : View.GONE);
+                            return;
+                        }
                         if (checked) {
                             vh.mCheckedOverlayView.setVisibility(View.VISIBLE);
                         }


### PR DESCRIPTION
java.lang.IllegalStateException: Cannot start this animator on a detached view!
	at android.view.RenderNode.addAnimator(RenderNode.java:812)
	at android.view.RenderNodeAnimator.setTarget(RenderNodeAnimator.java:300)
	at android.view.RenderNodeAnimator.setTarget(RenderNodeAnimator.java:282)
	at android.animation.RevealAnimator.<init>(RevealAnimator.java:37)
	at android.view.ViewAnimationUtils.createCircularReveal(ViewAnimationUtils.java:55)
	at com.google.android.apps.muzei.gallery.GallerySettingsActivity$18$3.run(GallerySettingsActivity.java:896)

Caused by attempting to create a circular reveal on a detached view. Simple enough to not run the animation if the view is detached.