### PR TITLE
Use try-with-resources when possible

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
@@ -445,23 +445,19 @@ public class MuzeiDocumentsProvider extends DocumentsProvider {
         options.inJustDecodeBounds = false;
         Bitmap bitmap = BitmapFactory.decodeStream(contentResolver.openInputStream(artworkUri), null, options);
         // Write out the thumbnail to a temporary file
-        FileOutputStream out = null;
-        try {
-            if (tempFile == null) {
+        if (tempFile == null) {
+            try {
                 tempFile = File.createTempFile("thumbnail", null, getContext().getCacheDir());
+            } catch (IOException e) {
+                Log.e(TAG, "Error writing thumbnail", e);
+                return null;
             }
-            out = new FileOutputStream(tempFile);
+        }
+        try (FileOutputStream out = new FileOutputStream(tempFile)) {
             bitmap.compress(Bitmap.CompressFormat.PNG, 90, out);
         } catch (IOException e) {
             Log.e(TAG, "Error writing thumbnail", e);
             return null;
-        } finally {
-            if (out != null)
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    Log.e(TAG, "Error closing thumbnail", e);
-                }
         }
         return new AssetFileDescriptor(ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY), 0,
                 AssetFileDescriptor.UNKNOWN_LENGTH);

--- a/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
@@ -199,17 +199,11 @@ public class MuzeiContract {
          */
         public static com.google.android.apps.muzei.api.Artwork getCurrentArtwork(Context context) {
             ContentResolver contentResolver = context.getContentResolver();
-            Cursor cursor = contentResolver.query(CONTENT_URI, null, null, null, null);
-            if (cursor == null) {
-                return null;
-            }
-            try {
-                if (!cursor.moveToFirst()) {
+            try (Cursor cursor = contentResolver.query(CONTENT_URI, null, null, null, null)) {
+                if (cursor == null || !cursor.moveToFirst()) {
                     return null;
                 }
                 return com.google.android.apps.muzei.api.Artwork.fromCursor(cursor);
-            } finally {
-                cursor.close();
             }
         }
 

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -193,17 +193,12 @@ public class SourceManager {
     }
 
     public static ComponentName getSelectedSource(Context context) {
-        Cursor data = context.getContentResolver().query(MuzeiContract.Sources.CONTENT_URI,
+        try (Cursor data = context.getContentResolver().query(MuzeiContract.Sources.CONTENT_URI,
                 new String[] {MuzeiContract.Sources.COLUMN_NAME_COMPONENT_NAME},
-                MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED + "=1", null, null);
-        try {
+                MuzeiContract.Sources.COLUMN_NAME_IS_SELECTED + "=1", null, null)) {
             return data != null && data.moveToFirst()
                     ? ComponentName.unflattenFromString(data.getString(0))
                     : null;
-        } finally {
-            if (data != null) {
-                data.close();
-            }
         }
     }
 

--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -59,8 +59,7 @@ public class RealRenderController extends RenderController {
         try {
             // Check if there's rotation
             int rotation = 0;
-            try {
-                InputStream in = mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI);
+            try (InputStream in = mContext.getContentResolver().openInputStream(MuzeiContract.Artwork.CONTENT_URI)) {
                 if (in == null) {
                     return null;
                 }

--- a/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
@@ -83,10 +83,8 @@ public class DownloadArtworkTask extends AsyncTask<Void, Void, Boolean> {
         }
         Uri imageUri = Uri.parse(imageUriString);
         data.close();
-        OutputStream out = null;
-        InputStream in = null;
-        try {
-            out = resolver.openOutputStream(artworkUri);
+        try (OutputStream out = resolver.openOutputStream(artworkUri);
+             InputStream in = out != null ? openUri(mApplicationContext, imageUri) : null) {
             if (out == null) {
                 // We've already downloaded the file
                 return true;
@@ -94,7 +92,6 @@ public class DownloadArtworkTask extends AsyncTask<Void, Void, Boolean> {
             // Only publish progress (i.e., say we've started loading the artwork)
             // if we actually need to download the artwork
             publishProgress();
-            in = openUri(mApplicationContext, imageUri);
             byte[] buffer = new byte[1024];
             int bytesRead;
             while ((bytesRead = in.read(buffer)) > 0) {
@@ -104,21 +101,6 @@ public class DownloadArtworkTask extends AsyncTask<Void, Void, Boolean> {
         } catch (IOException e) {
             Log.e(TAG, "Error downloading artwork", e);
             return false;
-        } finally {
-            try {
-                if (in != null) {
-                    in.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing artwork input stream", e);
-            }
-            try {
-                if (out != null) {
-                    out.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing artwork output stream", e);
-            }
         }
         return true;
     }

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
@@ -378,14 +378,11 @@ public class GalleryProvider extends ContentProvider {
         if (context == null) {
             return;
         }
-        InputStream in = null;
-        OutputStream out = null;
-        try {
-            in = context.getContentResolver().openInputStream(Uri.parse(uri));
+        try (InputStream in = context.getContentResolver().openInputStream(Uri.parse(uri));
+             OutputStream out = in != null ? new FileOutputStream(destFile) : null) {
             if (in == null) {
                 return;
             }
-            out = new FileOutputStream(destFile);
             byte[] buffer = new byte[1024];
             int bytesRead;
             while ((bytesRead = in.read(buffer)) > 0) {
@@ -394,17 +391,6 @@ public class GalleryProvider extends ContentProvider {
             out.flush();
         } catch (SecurityException e) {
             throw new IOException("Unable to read Uri: " + uri, e);
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch(IOException ignored) {}
-            }
-            if (out != null) {
-                try {
-                    out.close();
-                } catch(IOException ignored) {}
-            }
         }
     }
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/datalayer/ArtworkCacheIntentService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/datalayer/ArtworkCacheIntentService.java
@@ -136,11 +136,9 @@ public class ArtworkCacheIntentService extends IntentService {
             Log.w(TAG, "Unable to write artwork information to MuzeiProvider");
             return false;
         }
-        OutputStream out = null;
         DataApi.GetFdForAssetResult result = null;
         InputStream in = null;
-        try {
-            out = getContentResolver().openOutputStream(artworkUri);
+        try (OutputStream out = getContentResolver().openOutputStream(artworkUri)) {
             if (out == null) {
                 // We've already cached the artwork previously, so call this a success
                 return true;
@@ -170,13 +168,6 @@ public class ArtworkCacheIntentService extends IntentService {
             }
             if (result != null) {
                 result.release();
-            }
-            try {
-                if (out != null) {
-                    out.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing artwork output stream", e);
             }
         }
         return true;


### PR DESCRIPTION
With a minSdkVersion of 19, we can use try-with-resources to automatically close Cursors, InputStreams, and OutputStreams instead of needing finally blocks.