### PR TITLE
Catch FileUriExposedExceptions when starting view intents

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -20,7 +20,6 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
-import android.annotation.TargetApi;
 import android.app.WallpaperManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
@@ -177,7 +176,9 @@ public class MuzeiActivity extends AppCompatActivity {
                         viewIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         try {
                             startActivity(viewIntent);
-                        } catch (ActivityNotFoundException | SecurityException e) {
+                        } catch (RuntimeException e) {
+                            // Catch ActivityNotFoundException, SecurityException,
+                            // and FileUriExposedException
                             Toast.makeText(MuzeiActivity.this, R.string.error_view_details,
                                     Toast.LENGTH_SHORT).show();
                             Log.e(TAG, "Error viewing artwork details.", e);

--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 
 name = 2.3
 # Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
-codeWear = 23008
+codeWear = 23010
 # Add one to codeWear to ensure a unique version code for the main app
-code = 23009
+code = 23011
 
 # Latest beta number for this version. Only applies to beta builds.
-betaNumber = Beta 5
+betaNumber = Beta 6


### PR DESCRIPTION
With Muzei targeting API 24 now, we cannot use startActivity with Intents that include file:// URIs. Unfortunately, at least one extension sends such view intents. We now catch those errors.