### PR TITLE
2.3 Beta6: Fix FileUriExposedException, Gallery Permissions

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -268,21 +268,27 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         }
         if (viewIntent != null) {
             viewIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            PendingIntent nextPendingIntent = PendingIntent.getActivity(context, 0,
-                    viewIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT);
-            nb.addAction(
-                    R.drawable.ic_notif_info,
-                    context.getString(R.string.action_artwork_info),
-                    nextPendingIntent);
-            // Android Wear uses larger action icons so we build a
-            // separate action
-            extender.addAction(new NotificationCompat.Action.Builder(
-                    R.drawable.ic_notif_full_info,
-                    context.getString(R.string.action_artwork_info),
-                    nextPendingIntent)
-                    .extend(new NotificationCompat.Action.WearableExtender().setAvailableOffline(false))
-                    .build());
+            try {
+                PendingIntent nextPendingIntent = PendingIntent.getActivity(context, 0,
+                        viewIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT);
+                nb.addAction(
+                        R.drawable.ic_notif_info,
+                        context.getString(R.string.action_artwork_info),
+                        nextPendingIntent);
+                // Android Wear uses larger action icons so we build a
+                // separate action
+                extender.addAction(new NotificationCompat.Action.Builder(
+                        R.drawable.ic_notif_full_info,
+                        context.getString(R.string.action_artwork_info),
+                        nextPendingIntent)
+                        .extend(new NotificationCompat.Action.WearableExtender()
+                                .setAvailableOffline(false))
+                        .build());
+            } catch (RuntimeException ignored) {
+                // This is actually meant to catch a FileUriExposedException, but you can't
+                // have catch statements for exceptions that don't exist at your minSdkVersion
+            }
         }
         nb.extend(extender);
 

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
@@ -35,6 +35,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.BaseColumns;
@@ -306,7 +307,8 @@ public class GalleryProvider extends ContentProvider {
                 // We'll still have access to it directly
             }
         } else {
-            boolean haveUriPermission = context.checkCallingUriPermission(uriToTake,
+            boolean haveUriPermission = context.checkUriPermission(uriToTake,
+                    Binder.getCallingPid(), Binder.getCallingUid(),
                     Intent.FLAG_GRANT_READ_URI_PERMISSION) == PackageManager.PERMISSION_GRANTED;
             // If we only have permission to this URI via URI permissions (rather than directly,
             // such as if the URI is from our own app), it is from an external source and we need


### PR DESCRIPTION
Fixes crashes found in Muzei 2.3 Beta 6:

- Remove invalid artwork View Intents (invalid URIs and file:// URIs)
- Issues persisting permissions for selected Gallery art (causing photo removals, crashes, and artwork info issues)