### PR TITLE
Prepare for the Beta 7 Release

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 
 name = 2.3
 # Use 10*name for the base version code plus 2*(betaNumber-1) for beta builds
-codeWear = 23010
+codeWear = 23012
 # Add one to codeWear to ensure a unique version code for the main app
-code = 23011
+code = 23013
 
 # Latest beta number for this version. Only applies to beta builds.
-betaNumber = Beta 6
+betaNumber = Beta 7

--- a/wearable/src/main/AndroidManifest.xml
+++ b/wearable/src/main/AndroidManifest.xml
@@ -110,5 +110,9 @@
 
         <service android:name="com.google.android.apps.muzei.datalayer.ActivateMuzeiIntentService" />
         <activity android:name="android.support.wearable.activity.ConfirmationActivity" />
+
+        <meta-data
+            android:name="com.google.android.wearable.standalone"
+            android:value="false" />
     </application>
 </manifest>


### PR DESCRIPTION
Updates the version code for Beta 7 and sets the Wear app's [standalone flag](https://developer.android.com/wear/preview/features/app-distribution.html#specifying-app-as-standalone) to false as Muzei's Wear app still requires the phone app to load artwork.