### PR TITLE
Upgrade to tools 2.3.0-beta3 and re-enable build cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-    toolsPluginVersion = "2.3.0-beta2"
+    toolsPluginVersion = "2.3.0-beta3"
     googleServicesPluginVersion = "3.0.0"
     compileSdkVersion = 25
     buildToolsVersion = "25.0.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048M
-android.enableBuildCache=false


### PR DESCRIPTION
2.3.0-beta3 fixes https://code.google.com/p/android/issues/detail?id=229171 which allows us to re-enable using the build cache