### PR TITLE
Reduce memory usage, fix activity leak

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -288,7 +288,6 @@ public class MuzeiWallpaperService extends GLWallpaperService {
 
         @Override
         public void onDestroy() {
-            super.onDestroy();
             EventBus.getDefault().unregister(this);
             if (mWallpaperActivated) {
                 FirebaseAnalytics.getInstance(MuzeiWallpaperService.this).logEvent("wallpaper_destroyed", null);
@@ -310,6 +309,7 @@ public class MuzeiWallpaperService extends GLWallpaperService {
                 }
             });
             mRenderController.destroy();
+            super.onDestroy();
         }
 
         @Subscribe

--- a/main/src/main/java/com/google/android/apps/muzei/render/DemoRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/DemoRenderController.java
@@ -84,6 +84,7 @@ public class DemoRenderController extends RenderController {
         super.destroy();
         if (mCurrentScrollAnimator != null) {
             mCurrentScrollAnimator.cancel();
+            mCurrentScrollAnimator.removeAllListeners();
         }
         mHandler.removeCallbacksAndMessages(null);
     }

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
@@ -61,7 +61,7 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
     private boolean mDemoMode;
     private boolean mPreview;
     private int mMaxPrescaledBlurPixels;
-    private int mBlurKeyframes = 3;
+    private int mBlurKeyframes;
     private int mBlurredSampleSize;
     private int mMaxDim;
     private int mMaxGrey;
@@ -112,7 +112,7 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
     private int getNumberOfKeyframes() {
         ActivityManager activityManager = (ActivityManager)
                 mContext.getSystemService(Context.ACTIVITY_SERVICE);
-        return activityManager.isLowRamDevice() ? 1 : 5;
+        return activityManager.isLowRamDevice() ? 1 : 2;
     }
 
     public void recomputeMaxPrescaledBlurPixels() {

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
@@ -216,7 +216,6 @@ public class MuzeiRendererFragment extends Fragment implements
 
         @Override
         protected void onDetachedFromWindow() {
-            super.onDetachedFromWindow();
             mRenderController.destroy();
             queueEventOnGlThread(new Runnable() {
                 @Override
@@ -224,6 +223,7 @@ public class MuzeiRendererFragment extends Fragment implements
                     mRenderer.destroy();
                 }
             });
+            super.onDetachedFromWindow();
         }
     }
 }


### PR DESCRIPTION
Reduces the amount of memory needed by Muzei by
- Fixing a leak of `MuzeiActivity` (the main activity)
- Correctly destroying the `GLPicture`s by ensuring the `MuzeiBlurRenderer`'s `destroy()` method is called before the `GLThread` is finished
- Reducing the number of blur keyframes from 5 to 2 on non-low-RAM devices (reducing the number of pre-computed `GLPicture` instances)

Helps considerably with #31 although the `MuzeiWallpaperService` should be moved to its own process to provide the best memory savings (allowing the rest of the process to be completely removed from memory).