### PR TITLE
Fix complications not updating when there are multiple complications

### DIFF
--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
@@ -43,6 +43,10 @@ public class ArtworkComplicationJobService extends JobService {
 
     static void scheduleComplicationUpdateJob(Context context) {
         JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        if (jobScheduler.getPendingJob(ARTWORK_COMPLICATION_JOB_ID) != null) {
+            // Already scheduled, nothing else to do
+            return;
+        }
         ComponentName componentName = new ComponentName(context, ArtworkComplicationJobService.class);
         jobScheduler.schedule(new JobInfo.Builder(ARTWORK_COMPLICATION_JOB_ID, componentName)
                 .addTriggerContentUri(new JobInfo.TriggerContentUri(

--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationProviderService.java
@@ -66,9 +66,7 @@ public class ArtworkComplicationProviderService extends ComplicationProviderServ
         Set<String> complications = preferences.getStringSet(KEY_COMPLICATION_IDS, new TreeSet<String>());
         complications.add(Integer.toString(complicationId));
         preferences.edit().putStringSet(KEY_COMPLICATION_IDS, complications).apply();
-        if (complications.size() == 1) {
-            ArtworkComplicationJobService.scheduleComplicationUpdateJob(this);
-        }
+        ArtworkComplicationJobService.scheduleComplicationUpdateJob(this);
     }
 
     @Override


### PR DESCRIPTION


Instead of checking for the count in the ProviderService, check for the existence of a pending job in the JobService. This is more resilient to failures as it keeps the logic on the JobScheduler side rather than trying to track if the job is scheduled separately.