### PR TITLE
Prevent ConcurrentModificationException when using GalleryProvider

### DIFF
--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryProvider.java
@@ -167,6 +167,7 @@ public class GalleryProvider extends ContentProvider {
         try {
             return super.applyBatch(operations);
         } finally {
+            holdNotifyChange = false;
             Context context = getContext();
             if (context != null) {
                 ContentResolver contentResolver = context.getContentResolver();


### PR DESCRIPTION
Exception java.util.ConcurrentModificationException:
java.util.LinkedHashMap$LinkedHashIterator.remove (LinkedHashMap.java:356)
com.google.android.apps.muzei.gallery.GalleryProvider.applyBatch (GalleryProvider.java:178)
android.content.ContentProvider$Transport.applyBatch (ContentProvider.java:315)
android.content.ContentProviderClient.applyBatch (ContentProviderClient.java:419)
android.content.ContentResolver.applyBatch (ContentResolver.java:1286)
com.google.android.apps.muzei.gallery.GallerySettingsActivity$19.run (GallerySettingsActivity.java:1047)
android.os.Handler.handleCallback (Handler.java:739)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:148)
android.os.HandlerThread.run (HandlerThread.java:61)