### PR TITLE
Remove pending job check from complication scheduling

### DIFF
--- a/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/complications/ArtworkComplicationJobService.java
@@ -47,13 +47,6 @@ public class ArtworkComplicationJobService extends JobService {
 
     static void scheduleComplicationUpdateJob(Context context) {
         JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
-        if (jobScheduler.getPendingJob(ARTWORK_COMPLICATION_JOB_ID) != null) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Job already scheduled");
-            }
-            // Already scheduled, nothing else to do
-            return;
-        }
         ComponentName componentName = new ComponentName(context, ArtworkComplicationJobService.class);
         int result = jobScheduler.schedule(new JobInfo.Builder(ARTWORK_COMPLICATION_JOB_ID, componentName)
                 .addTriggerContentUri(new JobInfo.TriggerContentUri(


### PR DESCRIPTION
When calling scheduleComplicationUpdateJob from within onStartJob, the job is still marked as pending. This meant that the pending job check made it so that the job was only scheduled once, rather than repeatedly every time the job is started. As JobScheduler automatically replaces pending jobs with the newly scheduled job, there's no downside to scheduling it every time.