### PR TITLE
Fix NextArtworkActivity so that it works correctly

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -133,6 +133,9 @@
         <activity android:name="com.google.android.apps.muzei.NextArtworkActivity"
             android:label="@string/action_next_artwork"
             android:icon="@drawable/ic_next_artwork"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.NoDisplay"/>
 
         <!-- Watch for source package changes -->


### PR DESCRIPTION
It needs to be exported so that third party launchers can access it. excludeFromRecents and a separate taskAffinity ensure that it is not added to Muzei's task.