### PR TITLE
Handle widgets of width and height of zero pixels

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
@@ -148,7 +148,8 @@ class AppWidgetUpdateTask extends AsyncTask<Void,Void,Boolean> {
     }
 
     private Bitmap scaleBitmap(Bitmap image, int widgetWidth, int widgetHeight) {
-        if (image == null || image.getWidth() == 0 || image.getHeight() == 0) {
+        if (image == null || image.getWidth() == 0 || image.getHeight() == 0 ||
+                widgetWidth == 0 || widgetHeight == 0) {
             return null;
         }
         int largestDimension = Math.max(widgetWidth, widgetHeight);


### PR DESCRIPTION
Why a widget would be zero pixels in width and height, I don't know, but we shouldn't generate a scaled Bitmap in those cases.

Caused by java.lang.IllegalArgumentException: width and height must be > 0
android.graphics.Bitmap.createBitmap (Bitmap.java:829)
android.graphics.Bitmap.createBitmap (Bitmap.java:808)
android.graphics.Bitmap.createBitmap (Bitmap.java:739)
android.graphics.Bitmap.createScaledBitmap (Bitmap.java:615)
com.google.android.apps.muzei.widget.AppWidgetUpdateTask.scaleBitmap (AppWidgetUpdateTask.java:171)
com.google.android.apps.muzei.widget.AppWidgetUpdateTask.doInBackground (AppWidgetUpdateTask.java:131)
com.google.android.apps.muzei.widget.AppWidgetUpdateTask.doInBackground (AppWidgetUpdateTask.java:52)
android.os.AsyncTask$2.call (AsyncTask.java:295)
java.util.concurrent.FutureTask.run (FutureTask.java:237)
android.os.AsyncTask$SerialExecutor$1.run (AsyncTask.java:234)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1113)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:588)
java.lang.Thread.run (Thread.java:818)