### PR TITLE
Improve build speeds

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -29,6 +29,8 @@ android {
     def Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))
 
+    dexOptions.preDexLibraries true
+
     defaultConfig {
         applicationId "net.nurik.roman.muzei"
         minSdkVersion 19
@@ -62,6 +64,7 @@ android {
             // Android Lollipop without time consuming dex merging processes.
             minSdkVersion 21
             multiDexEnabled true
+            resConfigs "en"
         }
 
         prod {

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -25,6 +25,8 @@ android {
 
     publishNonDefault true
 
+    dexOptions.preDexLibraries true
+
     defaultConfig {
         applicationId "net.nurik.roman.muzei"
         minSdkVersion 23
@@ -55,6 +57,7 @@ android {
         dev {
             // Pre-dex each module and produce an APK to avoid the time consuming dex merging process
             multiDexEnabled true
+            resConfigs "en"
         }
 
         prod {


### PR DESCRIPTION
Add dexOptions.preDexLibraries true and use resConfigs "en" for the dev product flavor.