### PR TITLE
Fix null Uri passed to GallerySettingsActivity

### DIFF
--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -1048,10 +1048,17 @@ public class GallerySettingsActivity extends AppCompatActivity
         if (clipData != null) {
             int count = clipData.getItemCount();
             for (int i = 0; i < count; i++) {
-                uris.add(clipData.getItemAt(i).getUri());
+                Uri uri = clipData.getItemAt(i).getUri();
+                if (uri != null) {
+                    uris.add(uri);
+                }
             }
         }
 
+        if (uris.isEmpty()) {
+            // Nothing to do, so we can avoid posting the runnable at all
+            return;
+        }
         // Update chosen URIs
         runOnHandlerThread(new Runnable() {
             @Override


### PR DESCRIPTION
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.net.Uri.toString()' on a null object reference
com.google.android.apps.muzei.gallery.GallerySettingsActivity$19.run (GallerySettingsActivity.java:1042)
android.os.Handler.handleCallback (Handler.java:739)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:148)
android.os.HandlerThread.run (HandlerThread.java:61)