### PR TITLE
Fix crash on zero size Bitmaps in GLPictureSet.load

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
@@ -312,7 +312,8 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
         }
 
         public void load(BitmapRegionLoader bitmapRegionLoader) {
-            mHasBitmap = (bitmapRegionLoader != null);
+            mHasBitmap = bitmapRegionLoader != null
+                    && bitmapRegionLoader.getWidth() != 0 && bitmapRegionLoader.getHeight() != 0;
             mBitmapAspectRatio = mHasBitmap
                     ? bitmapRegionLoader.getWidth() * 1f / bitmapRegionLoader.getHeight()
                     : 1f;
@@ -321,7 +322,7 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
 
             destroyPictures();
 
-            if (bitmapRegionLoader != null) {
+            if (mHasBitmap) {
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 Rect rect = new Rect();
                 int originalWidth = bitmapRegionLoader.getWidth();
@@ -367,7 +368,8 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
                     rect.set(0, 0, originalWidth, originalHeight);
                     tempBitmap = bitmapRegionLoader.decodeRegion(rect, options);
 
-                    if (tempBitmap != null) {
+                    if (tempBitmap != null
+                            && tempBitmap.getWidth() != 0 && tempBitmap.getHeight() != 0) {
                         // Next, create a scaled down version of the bitmap so that the blur radius
                         // looks appropriate (tempBitmap will likely be bigger than the final
                         // blurred bitmap, and thus the blur may look smaller if we just used


### PR DESCRIPTION
Exception java.lang.IllegalArgumentException: width must be > 0
android.graphics.Bitmap.checkWidthHeight (Bitmap.java:378)
android.graphics.Bitmap.createBitmap (Bitmap.java:684)
android.graphics.Bitmap.createScaledBitmap (Bitmap.java:615)
com.google.android.apps.muzei.render.MuzeiBlurRenderer$GLPictureSet.load (MuzeiBlurRenderer.java:378)
com.google.android.apps.muzei.render.MuzeiBlurRenderer.setAndConsumeBitmapRegionLoader (MuzeiBlurRenderer.java:262)
com.google.android.apps.muzei.render.MuzeiBlurRenderer.onSurfaceCreated (MuzeiBlurRenderer.java:169)
net.rbgrn.android.glwallpaperservice.GLThread.guardedRun (GLWallpaperService.java:662)
net.rbgrn.android.glwallpaperservice.GLThread.run (GLWallpaperService.java:536)

Exception java.lang.IllegalArgumentException: width must be > 0
android.graphics.Bitmap.nativeCreateScaledBitmap (Bitmap.java)
android.graphics.Bitmap.createScaledBitmap (Bitmap.java:932)
com.google.android.apps.muzei.render.MuzeiBlurRenderer$GLPictureSet.load (MuzeiBlurRenderer.java:378)
com.google.android.apps.muzei.render.MuzeiBlurRenderer.setAndConsumeBitmapRegionLoader (MuzeiBlurRenderer.java:262)
com.google.android.apps.muzei.render.MuzeiBlurRenderer.onSurfaceCreated (MuzeiBlurRenderer.java:169)
net.rbgrn.android.glwallpaperservice.GLThread.guardedRun (GLWallpaperService.java:662)
net.rbgrn.android.glwallpaperservice.GLThread.run (GLWallpaperService.java:536)