### PR TITLE
Move API versioning to version.properties, switch to integer

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,8 +18,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
+def Properties versionProps = new Properties()
+versionProps.load(new FileInputStream(file('../version.properties')))
+
 group = 'com.google.android.apps.muzei'
-version = '2.3'
+version = versionProps['apiName']
+
 
 def Properties props = new Properties()
 props.load(new FileInputStream(file('../local.properties')))
@@ -39,7 +43,7 @@ android {
         minSdkVersion 11
         targetSdkVersion rootProject.ext.targetSdkVersion
 
-        manifestPlaceholders = [api_version: version]
+        manifestPlaceholders = [api_version: versionProps['apiCode'].toInteger()]
     }
 
     compileOptions {

--- a/version.properties
+++ b/version.properties
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+apiName = 2.3
+apiCode = 230
+
 name = 2.3.1
 # Version number + unique ID for the build
 codeWear = 23105


### PR DESCRIPTION
Use a separate API code for injecting into the API manifest metadata element.