### PR TITLE
Fix blurring destination Allocation

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.java
@@ -384,15 +384,14 @@ public class MuzeiBlurRenderer implements GLSurfaceView.Renderer {
                         }
 
                         // And finally, create a blurred copy for each keyframe.
-                        ImageBlurrer blurrer = new ImageBlurrer(mContext);
+                        ImageBlurrer blurrer = new ImageBlurrer(mContext, scaledBitmap);
                         for (int f = 1; f <= mBlurKeyframes; f++) {
                             float desaturateAmount = mMaxGrey / 500f * f / mBlurKeyframes;
                             float blurRadius = 0f;
                             if (mMaxPrescaledBlurPixels > 0) {
                                 blurRadius = blurRadiusAtFrame(f);
                             }
-                            Bitmap blurredBitmap = blurrer.blurBitmap(
-                                    scaledBitmap, blurRadius, desaturateAmount);
+                            Bitmap blurredBitmap = blurrer.blurBitmap(blurRadius, desaturateAmount);
                             mPictures[f] = new GLPicture(blurredBitmap);
                             if (blurredBitmap != null) {
                                 blurredBitmap.recycle();

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.java
@@ -107,9 +107,8 @@ public class MuzeiRendererFragment extends Fragment implements
         public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
             if (!mDemoFocus) {
                 // Blur
-                ImageBlurrer blurrer = new ImageBlurrer(getActivity());
-                Bitmap blurred = blurrer.blurBitmap(bitmap,
-                        ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0);
+                ImageBlurrer blurrer = new ImageBlurrer(getActivity(), bitmap);
+                Bitmap blurred = blurrer.blurBitmap(ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0);
                 blurrer.destroy();
 
                 // Dim

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiWatchFace.java
@@ -336,8 +336,8 @@ public class MuzeiWatchFace extends CanvasWatchFaceService {
                         (int) (scalingFactor * mBackgroundBitmap.getHeight()),
                         true /* filter */);
             }
-            ImageBlurrer blurrer = new ImageBlurrer(MuzeiWatchFace.this);
-            mBackgroundScaledBlurredBitmap = blurrer.blurBitmap(mBackgroundScaledBitmap,
+            ImageBlurrer blurrer = new ImageBlurrer(MuzeiWatchFace.this, mBackgroundScaledBitmap);
+            mBackgroundScaledBlurredBitmap = blurrer.blurBitmap(
                     ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS / 2, 0f);
             blurrer.destroy();
         }

--- a/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
@@ -144,9 +144,8 @@ public class PanView extends View {
             float scalingFactor = mWidth * 1f / width;
             mScaledImage = Bitmap.createScaledBitmap(mImage, mWidth, (int)(scalingFactor * height), true);
         }
-        ImageBlurrer blurrer = new ImageBlurrer(getContext());
-        mBlurredImage = blurrer.blurBitmap(mScaledImage,
-                ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0f);
+        ImageBlurrer blurrer = new ImageBlurrer(getContext(), mScaledImage);
+        mBlurredImage = blurrer.blurBitmap(ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0f);
         blurrer.destroy();
         // Center the image
         mOffsetX = (mWidth - mScaledImage.getWidth()) / 2;


### PR DESCRIPTION
ImageBlurrer attempts to reuse an Allocation when the Bitmap used to create it was recycled (by MuzeiBlurRenderer). Creating an Allocation wraps the Bitmap, rather than creating a copy so we can create a new Allocation for each new destination Bitmap, preventing reuse abuse.

Moves the source Bitmap input to ImageBlurrer to the constructor to make it clear that there is always one source image (passing in a different image of a different size would have failed anyways). Also fixed an issue where the ScriptIntrinsicColorMatrix was not destroyed.