### PR TITLE
Limit the cache size to 10 images per source + persisted URIs

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -28,6 +28,13 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion rootProject.ext.targetSdkVersion
+
+        def documentsAuthorityValue = "com.google.android.apps.muzei.documents"
+        manifestPlaceholders =
+                [documentsAuthority: documentsAuthorityValue]
+        buildConfigField("String",
+                "DOCUMENTS_AUTHORITY",
+                "\"${documentsAuthorityValue}\"")
     }
 
     compileOptions {

--- a/android-client-common/src/main/AndroidManifest.xml
+++ b/android-client-common/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
             android:permission="android.permission.BIND_JOB_SERVICE" />
         <provider
             android:name="com.google.android.apps.muzei.provider.MuzeiDocumentsProvider"
-            android:authorities="com.google.android.apps.muzei.documents"
+            android:authorities="${documentsAuthority}"
             android:grantUriPermissions="true"
             android:exported="true"
             android:permission="android.permission.MANAGE_DOCUMENTS">


### PR DESCRIPTION
Instead of infinitely storing all past artwork, Muzei should only
store the last 10 artwork from each source.

A special exception should be made for artwork that other apps have
persistent access to via the MuzeiDocumentsProvider - those artwork
should never be deleted. Due to how the persistent Uris work on API 25
and lower devices, the Gallery source must manually tell the
MuzeiDocumentsProvider that it is persisting/releasing each URI to avoid
those URIs from being deleted by the MuzeiProvider.

Fixes #383 