### PR TITLE
Replace moveSharedPreferencesFrom with our own preference migration

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.java
@@ -18,7 +18,6 @@ package com.google.android.apps.muzei.settings;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.os.UserManagerCompat;
@@ -33,52 +32,58 @@ public class Prefs {
     public static final String PREF_DISABLE_BLUR_WHEN_LOCKED = "disable_blur_when_screen_locked_enabled";
 
     private static final String WALLPAPER_PREFERENCES_NAME = "wallpaper_preferences";
-    private static final String PREF_MIGRATED_FROM_DEFAULT = "migrated_from_default";
+    private static final String PREF_MIGRATED = "migrated_from_default";
 
     public synchronized static SharedPreferences getSharedPreferences(Context context) {
         Context deviceProtectedContext =
                 ContextCompat.createDeviceProtectedStorageContext(context);
         if (UserManagerCompat.isUserUnlocked(context)) {
+            // First migrate the wallpaper settings to their own file
             SharedPreferences defaultSharedPreferences =
                     PreferenceManager.getDefaultSharedPreferences(context);
-            // First migrate the wallpaper settings to their own file
-            if (!defaultSharedPreferences.getBoolean(PREF_MIGRATED_FROM_DEFAULT, false)) {
-                SharedPreferences.Editor defaultEditor = defaultSharedPreferences.edit();
-                SharedPreferences.Editor editor = context.getSharedPreferences(
-                        WALLPAPER_PREFERENCES_NAME, Context.MODE_PRIVATE).edit();
+            SharedPreferences wallpaperPreferences = context.getSharedPreferences(
+                    WALLPAPER_PREFERENCES_NAME, Context.MODE_PRIVATE);
+            migratePreferences(defaultSharedPreferences, wallpaperPreferences);
 
-                if (defaultSharedPreferences.contains(PREF_GREY_AMOUNT)) {
-                    editor.putInt(PREF_GREY_AMOUNT,
-                            defaultSharedPreferences.getInt(PREF_GREY_AMOUNT, 0));
-                    defaultEditor.remove(PREF_GREY_AMOUNT);
-                }
-                if (defaultSharedPreferences.contains(PREF_DIM_AMOUNT)) {
-                    editor.putInt(PREF_DIM_AMOUNT,
-                            defaultSharedPreferences.getInt(PREF_DIM_AMOUNT, 0));
-                    defaultEditor.remove(PREF_DIM_AMOUNT);
-                }
-                if (defaultSharedPreferences.contains(PREF_BLUR_AMOUNT)) {
-                    editor.putInt(PREF_BLUR_AMOUNT,
-                            defaultSharedPreferences.getInt(PREF_BLUR_AMOUNT, 0));
-                    defaultEditor.remove(PREF_BLUR_AMOUNT);
-                }
-                if (defaultSharedPreferences.contains(PREF_DISABLE_BLUR_WHEN_LOCKED)) {
-                    editor.putBoolean(PREF_DISABLE_BLUR_WHEN_LOCKED,
-                            defaultSharedPreferences.getBoolean(PREF_DISABLE_BLUR_WHEN_LOCKED, false));
-                    defaultEditor.remove(PREF_DISABLE_BLUR_WHEN_LOCKED);
-                }
-                defaultEditor.putBoolean(PREF_MIGRATED_FROM_DEFAULT, true);
-                defaultEditor.apply();
-                editor.apply();
-            }
             // Now migrate the file to device protected storage if available
-            if (deviceProtectedContext != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                deviceProtectedContext.moveSharedPreferencesFrom(context, WALLPAPER_PREFERENCES_NAME);
+            if (deviceProtectedContext != null) {
+                SharedPreferences deviceProtectedPreferences = deviceProtectedContext.getSharedPreferences(
+                        WALLPAPER_PREFERENCES_NAME, Context.MODE_PRIVATE);
+                migratePreferences(wallpaperPreferences, deviceProtectedPreferences);
             }
         }
         // Now open the correct SharedPreferences
         Context contextToUse = deviceProtectedContext != null ? deviceProtectedContext : context;
         return contextToUse.getSharedPreferences(WALLPAPER_PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+    private static void migratePreferences(SharedPreferences source, SharedPreferences destination) {
+        if (source.getBoolean(PREF_MIGRATED, false)) {
+            return;
+        }
+        SharedPreferences.Editor sourceEditor = source.edit();
+        SharedPreferences.Editor destinationEditor = destination.edit();
+
+        if (source.contains(PREF_GREY_AMOUNT)) {
+            destinationEditor.putInt(PREF_GREY_AMOUNT, source.getInt(PREF_GREY_AMOUNT, 0));
+            sourceEditor.remove(PREF_GREY_AMOUNT);
+        }
+        if (source.contains(PREF_DIM_AMOUNT)) {
+            destinationEditor.putInt(PREF_DIM_AMOUNT, source.getInt(PREF_DIM_AMOUNT, 0));
+            sourceEditor.remove(PREF_DIM_AMOUNT);
+        }
+        if (source.contains(PREF_BLUR_AMOUNT)) {
+            destinationEditor.putInt(PREF_BLUR_AMOUNT, source.getInt(PREF_BLUR_AMOUNT, 0));
+            sourceEditor.remove(PREF_BLUR_AMOUNT);
+        }
+        if (source.contains(PREF_DISABLE_BLUR_WHEN_LOCKED)) {
+            destinationEditor.putBoolean(PREF_DISABLE_BLUR_WHEN_LOCKED,
+                    source.getBoolean(PREF_DISABLE_BLUR_WHEN_LOCKED, false));
+            sourceEditor.remove(PREF_DISABLE_BLUR_WHEN_LOCKED);
+        }
+        sourceEditor.putBoolean(PREF_MIGRATED, true);
+        sourceEditor.apply();
+        destinationEditor.apply();
     }
 
     private Prefs() {


### PR DESCRIPTION
moveSharedPreferencesFrom has the unfortunate side effect of requiring
users force stop Muzei (or reboot their device) after the migration
to get their user settings to work again. By moving to our own
migration strategy, we can ensure that upgrading users can instantly
use their current settings.