### PR TITLE
Fix PanView issues with zero size images

### DIFF
--- a/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
+++ b/wearable/src/main/java/com/google/android/apps/muzei/util/PanView.java
@@ -132,17 +132,19 @@ public class PanView extends View {
     }
 
     private void updateScaledImage() {
-        if (mImage == null) {
+        if (mImage == null || mImage.getWidth() == 0 || mImage.getHeight() == 0) {
             return;
         }
         int width = mImage.getWidth();
         int height = mImage.getHeight();
         if (width > height) {
             float scalingFactor = mHeight * 1f / height;
-            mScaledImage = Bitmap.createScaledBitmap(mImage, (int)(scalingFactor * width), mHeight, true);
+            int scaledWidth = Math.max(1, (int) (scalingFactor * width));
+            mScaledImage = Bitmap.createScaledBitmap(mImage, scaledWidth, mHeight, true);
         } else {
             float scalingFactor = mWidth * 1f / width;
-            mScaledImage = Bitmap.createScaledBitmap(mImage, mWidth, (int)(scalingFactor * height), true);
+            int scaledHeight = Math.max(1, (int) (scalingFactor * height));
+            mScaledImage = Bitmap.createScaledBitmap(mImage, mWidth, scaledHeight, true);
         }
         ImageBlurrer blurrer = new ImageBlurrer(getContext(), mScaledImage);
         mBlurredImage = blurrer.blurBitmap(ImageBlurrer.MAX_SUPPORTED_BLUR_PIXELS, 0f);


### PR DESCRIPTION
Done in two parts: excluding images with a zero width or height and
ensuring that the scaled sizes are at least 1 pixel.

Exception java.lang.IllegalArgumentException: width and height must be > 0
android.graphics.Bitmap.createBitmap (Bitmap.java:877)
android.graphics.Bitmap.createBitmap (Bitmap.java:856)
android.graphics.Bitmap.createBitmap (Bitmap.java:787)
android.graphics.Bitmap.createScaledBitmap (Bitmap.java:663)
com.google.android.apps.muzei.util.PanView.updateScaledImage (PanView.java:145)
com.google.android.apps.muzei.util.PanView.setImage (PanView.java:123)
com.google.android.apps.muzei.FullScreenActivity.onLoadFinished (FullScreenActivity.java:211)
com.google.android.apps.muzei.FullScreenActivity.onLoadFinished (FullScreenActivity.java:51)
android.app.LoaderManagerImpl$LoaderInfo.callOnLoadFinished (LoaderManager.java:489)
android.app.LoaderManagerImpl$LoaderInfo.onLoadComplete (LoaderManager.java:457)
android.content.Loader.deliverResult (Loader.java:144)
android.content.AsyncTaskLoader.dispatchOnLoadComplete (AsyncTaskLoader.java:265)
android.content.AsyncTaskLoader$LoadTask.onPostExecute (AsyncTaskLoader.java:92)
android.os.AsyncTask.finish (AsyncTask.java:667)
android.os.AsyncTask.-wrap1 (AsyncTask.java)
android.os.AsyncTask$InternalHandler.handleMessage (AsyncTask.java:684)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loop (Looper.java:154)
android.app.ActivityThread.main (ActivityThread.java:6119)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:886)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:776)