### PR TITLE
Minor version bump for Support Library, Google Play services, Wearable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ ext {
     buildToolsVersion = "25.0.2"
     targetSdkVersion = 25
 
-    supportLibraryVersion = "25.3.0"
-    googlePlayServicesVersion = "10.2.0"
+    supportLibraryVersion = "25.3.1"
+    googlePlayServicesVersion = "10.2.1"
     okhttpVersion = "3.6.0"
     picassoVersion = "2.5.2"
 }

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -91,8 +91,8 @@ android {
 dependencies {
     compile "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
-    provided "com.google.android.wearable:wearable:2.0.0"
-    compile "com.google.android.support:wearable:2.0.0"
+    provided "com.google.android.wearable:wearable:2.0.1"
+    compile "com.google.android.support:wearable:2.0.1"
     // Only used because wearable dependency depends on an old version of the Support Library
     compile "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"


### PR DESCRIPTION
Upgrade:
- Support Library to 25.3.1
- Google Play services to 10.2.1
- Wearable Support Library to 2.0.1