### PR TITLE
Handle call() with persisted tree URIs

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/provider/MuzeiDocumentsProvider.java
@@ -129,10 +129,15 @@ public class MuzeiDocumentsProvider extends DocumentsProvider {
      * Transform a Document URI into the underlying Artwork URI
      */
     private static Uri getArtworkUriForDocumentUri(Uri documentUri) {
-        String documentId = DocumentsContract.getDocumentId(documentUri);
-        if (documentId != null && documentId.startsWith(ARTWORK_DOCUMENT_ID_PREFIX)) {
-            long artworkId = Long.parseLong(documentId.replace(ARTWORK_DOCUMENT_ID_PREFIX, ""));
-            return ContentUris.withAppendedId(MuzeiContract.Artwork.CONTENT_URI, artworkId);
+        try {
+            String documentId = DocumentsContract.getDocumentId(documentUri);
+            if (documentId != null && documentId.startsWith(ARTWORK_DOCUMENT_ID_PREFIX)) {
+                long artworkId = Long.parseLong(documentId.replace(ARTWORK_DOCUMENT_ID_PREFIX, ""));
+                return ContentUris.withAppendedId(MuzeiContract.Artwork.CONTENT_URI, artworkId);
+            }
+        } catch (IllegalArgumentException e) {
+            // We'll get an IllegalArgumentException on tree URIs, but these don't correspond with
+            // individual artwork, so we can ignore them
         }
         return null;
     }


### PR DESCRIPTION
Tree URIs without documents IDs don't correspond with individual artworks, so we can just ignore them.

Exception java.lang.IllegalArgumentException: Invalid URI: content://com.google.android.apps.muzei.documents/tree/by_date
android.provider.DocumentsContract.getDocumentId (DocumentsContract.java:917)
com.google.android.apps.muzei.provider.MuzeiDocumentsProvider.getArtworkUriForDocumentUri (MuzeiDocumentsProvider.java:132)
com.google.android.apps.muzei.provider.MuzeiDocumentsProvider.call (MuzeiDocumentsProvider.java:191)
android.content.ContentProvider$Transport.call (ContentProvider.java:404)
android.content.ContentResolver.call (ContentResolver.java:1449)
com.google.android.apps.muzei.gallery.GalleryProvider.deleteChosenPhotos (GalleryProvider.java:255)
com.google.android.apps.muzei.gallery.GalleryProvider.delete (GalleryProvider.java:204)
android.content.ContentProviderOperation.apply (ContentProviderOperation.java:311)
android.content.ContentProvider.applyBatch (ContentProvider.java:1785)
com.google.android.apps.muzei.gallery.GalleryProvider.applyBatch (GalleryProvider.java:168)
android.content.ContentProvider$Transport.applyBatch (ContentProvider.java:320)
android.content.ContentProviderClient.applyBatch (ContentProviderClient.java:438)
android.content.ContentResolver.applyBatch (ContentResolver.java:1319)
com.google.android.apps.muzei.gallery.GallerySettingsActivity$12$1.run (GallerySettingsActivity.java:531)
android.os.Handler.handleCallback (Handler.java:751)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:154)
android.os.HandlerThread.run (HandlerThread.java:61)