### PR TITLE
Catch NumberFormatException from ExifInterface

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RealRenderController.java
@@ -71,7 +71,7 @@ public class RealRenderController extends RenderController {
                     case ExifInterface.ORIENTATION_ROTATE_180: rotation = 180; break;
                     case ExifInterface.ORIENTATION_ROTATE_270: rotation = 270; break;
                 }
-            } catch (IOException|StackOverflowError e) {
+            } catch (IOException|NumberFormatException|StackOverflowError e) {
                 Log.w(TAG, "Couldn't open EXIF interface on artwork", e);
             }
             return BitmapRegionLoader.newInstance(

--- a/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wearable/WearableController.java
@@ -117,7 +117,7 @@ public class WearableController {
                 case ExifInterface.ORIENTATION_ROTATE_180: rotation = 180; break;
                 case ExifInterface.ORIENTATION_ROTATE_270: rotation = 270; break;
             }
-        } catch (IOException|StackOverflowError ignored) {
+        } catch (IOException|NumberFormatException|StackOverflowError ignored) {
         }
         return rotation;
     }


### PR DESCRIPTION
Caused by java.lang.NumberFormatException: Invalid int: "????"
java.lang.Integer.invalidInt (Integer.java:138)
java.lang.Integer.parse (Integer.java:410)
java.lang.Integer.parseInt (Integer.java:367)
java.lang.Integer.parseInt (Integer.java:334)
android.support.media.ExifInterface$ExifAttribute.getIntValue (ExifInterface.java:819)
android.support.media.ExifInterface.handleThumbnailFromJfif (ExifInterface.java:2869)
android.support.media.ExifInterface.setThumbnailData (ExifInterface.java:2841)
android.support.media.ExifInterface.loadAttributes (ExifInterface.java:1638)
android.support.media.ExifInterface.<init> (ExifInterface.java:1315)