### PR TITLE
Replace deprecated ExifInterface.getLatLong(float[])

### DIFF
--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
@@ -408,8 +408,8 @@ public class GalleryArtSource extends MuzeiArtSource {
                     values.put(GalleryContract.MetadataCache.COLUMN_NAME_DATETIME, date.getTime());
                 }
 
-                float[] latlong = new float[2];
-                if (exifInterface.getLatLong(latlong)) {
+                double[] latlong = exifInterface.getLatLong();
+                if (latlong != null) {
                     // Reverse geocode
                     List<Address> addresses = null;
                     try {


### PR DESCRIPTION
Use the new double[] getLatLong() method instead.