### PR TITLE
Fix NPE when adding images from Document Tree URI

### DIFF
--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
@@ -297,9 +297,14 @@ public class GalleryArtSource extends MuzeiArtSource {
     private int addAllImagesFromTree(final List<Uri> allImages, final Uri treeUri, final String parentDocumentId) {
         final Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri,
                 parentDocumentId);
-        Cursor children = getContentResolver().query(childrenUri,
-                new String[] { DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_MIME_TYPE},
-                null, null, null);
+        Cursor children = null;
+        try {
+            children = getContentResolver().query(childrenUri,
+                    new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_MIME_TYPE},
+                    null, null, null);
+        } catch (NullPointerException e) {
+            Log.e(TAG, "Error reading " + childrenUri, e);
+        }
         if (children == null) {
             return 0;
         }


### PR DESCRIPTION
We skip trees that error out.

Exception java.lang.NullPointerException: Attempt to get length of null array
android.os.Parcel.readException (Parcel.java:1690)
android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:183)
android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:135)
android.content.ContentProviderProxy.query (ContentProviderNative.java:421)
android.content.ContentResolver.query (ContentResolver.java:534)
android.content.ContentResolver.query (ContentResolver.java:475)
com.google.android.apps.muzei.gallery.GalleryArtSource.addAllImagesFromTree (GalleryArtSource.java:300)
com.google.android.apps.muzei.gallery.GalleryArtSource.publishNextArtwork (GalleryArtSource.java:193)
com.google.android.apps.muzei.gallery.GalleryArtSource.onUpdate (GalleryArtSource.java:157)
com.google.android.apps.muzei.api.MuzeiArtSource.processHandleCommand (MuzeiArtSource.java:784)
com.google.android.apps.muzei.api.MuzeiArtSource.onHandleIntent (MuzeiArtSource.java:690)
com.google.android.apps.muzei.gallery.GalleryArtSource.onHandleIntent (GalleryArtSource.java:141)
com.google.android.apps.muzei.api.MuzeiArtSource$ServiceHandler.handleMessage (MuzeiArtSource.java:311)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loop (Looper.java:154)
android.os.HandlerThread.run (HandlerThread.java:61)