### PR TITLE
Use the Lifecycle Architecture Component in MuzeiWallpaperService

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
+    compile "android.arch.lifecycle:runtime:1.0.0-alpha2"
 
     // :api is included as a transitive dependency from :android-client-common
     // compile project(':api')

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -34,3 +34,10 @@
 # okio
 
 -dontwarn okio.**
+
+# Android architecture components: Lifecycle
+-keepclassmembers class android.arch.lifecycle.Lifecycle$State { *; }
+-keepclassmembers class android.arch.lifecycle.Lifecycle$Event { *; }
+-keepclassmembers class * implements android.arch.lifecycle.LifecycleObserver {
+    @android.arch.lifecycle.OnLifecycleEvent *;
+}

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -81,6 +81,7 @@ public class MuzeiWallpaperService extends GLWallpaperService implements Lifecyc
         super.onCreate();
         mLifecycle = new LifecycleRegistry(this);
         mLifecycle.addObserver(new WallpaperAnalytics(this));
+        mLifecycle.addObserver(new SourceManager(this));
         if (UserManagerCompat.isUserUnlocked(this)) {
             mLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
             initialize();
@@ -104,7 +105,6 @@ public class MuzeiWallpaperService extends GLWallpaperService implements Lifecyc
     }
 
     private void initialize() {
-        SourceManager.subscribeToSelectedSource(MuzeiWallpaperService.this);
         mNetworkChangeReceiver = new NetworkChangeReceiver();
         IntentFilter networkChangeFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
         registerReceiver(mNetworkChangeReceiver, networkChangeFilter);
@@ -173,7 +173,6 @@ public class MuzeiWallpaperService extends GLWallpaperService implements Lifecyc
                 unregisterReceiver(mNetworkChangeReceiver);
                 mNetworkChangeReceiver = null;
             }
-            SourceManager.unsubscribeToSelectedSource(MuzeiWallpaperService.this);
         } else {
             unregisterReceiver(mUnlockReceiver);
         }

--- a/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceManager.java
@@ -16,6 +16,9 @@
 
 package com.google.android.apps.muzei;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.ComponentName;
 import android.content.ContentProviderOperation;
 import android.content.ContentValues;
@@ -52,14 +55,30 @@ import static com.google.android.apps.muzei.api.internal.ProtocolConstants.EXTRA
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.EXTRA_SUBSCRIBER_COMPONENT;
 import static com.google.android.apps.muzei.api.internal.ProtocolConstants.EXTRA_TOKEN;
 
-public class SourceManager {
+/**
+ * Class responsible for managing interactions with sources such as subscribing, unsubscribing, and sending actions.
+ */
+public class SourceManager implements LifecycleObserver {
     private static final String TAG = "SourceManager";
     private static final String PREF_SELECTED_SOURCE = "selected_source";
     private static final String PREF_SOURCE_STATES = "source_states";
     private static final String USER_PROPERTY_SELECTED_SOURCE = "selected_source";
     private static final String USER_PROPERTY_SELECTED_SOURCE_PACKAGE = "selected_source_package";
 
-    private SourceManager() {
+    private final Context mContext;
+
+    public SourceManager(Context context) {
+        mContext = context;
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    public void subscribeToSelectedSource() {
+        subscribeToSelectedSource(mContext);
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    public void unsubscribeToSelectedSource() {
+        unsubscribeToSelectedSource(mContext);
     }
 
     /**

--- a/main/src/main/java/com/google/android/apps/muzei/wallpaper/LockscreenObserver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wallpaper/LockscreenObserver.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.wallpaper;
+
+import android.app.KeyguardManager;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.support.v4.os.UserManagerCompat;
+
+import com.google.android.apps.muzei.MuzeiWallpaperService;
+import com.google.android.apps.muzei.settings.Prefs;
+
+/**
+ * LifecycleObserver responsible for monitoring the state of the lock screen
+ */
+public class LockscreenObserver implements LifecycleObserver {
+    private final Context mContext;
+    private final MuzeiWallpaperService.MuzeiWallpaperEngine mEngine;
+
+    private boolean mIsLockScreenVisibleReceiverRegistered = false;
+    private SharedPreferences.OnSharedPreferenceChangeListener
+            mLockScreenPreferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+        @Override
+        public void onSharedPreferenceChanged(final SharedPreferences sp, final String key) {
+            if (Prefs.PREF_DISABLE_BLUR_WHEN_LOCKED.equals(key)) {
+                if (sp.getBoolean(Prefs.PREF_DISABLE_BLUR_WHEN_LOCKED, false)) {
+                    IntentFilter intentFilter = new IntentFilter();
+                    intentFilter.addAction(Intent.ACTION_USER_PRESENT);
+                    intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+                    intentFilter.addAction(Intent.ACTION_SCREEN_ON);
+                    mContext.registerReceiver(mLockScreenVisibleReceiver, intentFilter);
+                    mIsLockScreenVisibleReceiverRegistered = true;
+                    // If the user is not yet unlocked (i.e., using Direct Boot), we should
+                    // immediately send the lock screen visible callback
+                    if (!UserManagerCompat.isUserUnlocked(mContext)) {
+                        mEngine.lockScreenVisibleChanged(true);
+                    }
+                } else if (mIsLockScreenVisibleReceiverRegistered) {
+                    mContext.unregisterReceiver(mLockScreenVisibleReceiver);
+                    mIsLockScreenVisibleReceiverRegistered = false;
+                }
+            }
+        }
+    };
+    private BroadcastReceiver mLockScreenVisibleReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            if (intent != null) {
+                if (Intent.ACTION_USER_PRESENT.equals(intent.getAction())) {
+                    mEngine.lockScreenVisibleChanged(false);
+                } else if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                    mEngine.lockScreenVisibleChanged(true);
+                } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
+                    KeyguardManager kgm = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+                    if (!kgm.inKeyguardRestrictedInputMode()) {
+                        mEngine.lockScreenVisibleChanged(false);
+                    }
+                }
+            }
+        }
+    };
+
+    public LockscreenObserver(Context context, MuzeiWallpaperService.MuzeiWallpaperEngine engine) {
+        mContext = context;
+        mEngine = engine;
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    public void registerOnSharedPreferenceChangeListener() {
+        SharedPreferences sp = Prefs.getSharedPreferences(mContext);
+        sp.registerOnSharedPreferenceChangeListener(mLockScreenPreferenceChangeListener);
+        // Trigger the initial registration if needed
+        mLockScreenPreferenceChangeListener.onSharedPreferenceChanged(sp,
+                Prefs.PREF_DISABLE_BLUR_WHEN_LOCKED);
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    public void unregisterOnSharedPreferenceChangeListener() {
+        if (mIsLockScreenVisibleReceiverRegistered) {
+            mContext.unregisterReceiver(mLockScreenVisibleReceiver);
+        }
+        Prefs.getSharedPreferences(mContext)
+                .unregisterOnSharedPreferenceChangeListener(mLockScreenPreferenceChangeListener);
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/wallpaper/NetworkChangeObserver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wallpaper/NetworkChangeObserver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.wallpaper;
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+
+import com.google.android.apps.muzei.NetworkChangeReceiver;
+import com.google.android.apps.muzei.sync.TaskQueueService;
+
+/**
+ * LifecycleObserver responsible for monitoring network connectivity and retrying artwork as necessary
+ */
+public class NetworkChangeObserver implements LifecycleObserver {
+    private final Context mContext;
+    private NetworkChangeReceiver mNetworkChangeReceiver;
+
+    public NetworkChangeObserver(Context context) {
+        mContext = context;
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    public void registerReceiver() {
+        mNetworkChangeReceiver = new NetworkChangeReceiver();
+        IntentFilter networkChangeFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
+        mContext.registerReceiver(mNetworkChangeReceiver, networkChangeFilter);
+
+        // Ensure we retry loading the artwork if the network changed while the wallpaper was disabled
+        ConnectivityManager connectivityManager = (ConnectivityManager) mContext.getSystemService(
+                Context.CONNECTIVITY_SERVICE);
+        Intent retryIntent = TaskQueueService.maybeRetryDownloadDueToGainedConnectivity(mContext);
+        if (retryIntent != null && connectivityManager.getActiveNetworkInfo() != null &&
+                connectivityManager.getActiveNetworkInfo().isConnected()) {
+            mContext.startService(retryIntent);
+        }
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    public void unregisterReceiver() {
+        mContext.unregisterReceiver(mNetworkChangeReceiver);
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/wallpaper/NotificationUpdater.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wallpaper/NotificationUpdater.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.wallpaper;
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.HandlerThread;
+
+import com.google.android.apps.muzei.NewWallpaperNotificationReceiver;
+import com.google.android.apps.muzei.api.MuzeiContract;
+
+/**
+ * LifecycleObserver which updates the notification when the artwork changes
+ */
+public class NotificationUpdater implements LifecycleObserver {
+    private final Context mContext;
+    private HandlerThread mNotificationHandlerThread;
+    private ContentObserver mNotificationContentObserver;
+
+    public NotificationUpdater(Context context) {
+        mContext = context;
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    public void registerContentObserver() {
+        // Set up a thread to update notifications whenever the artwork changes
+        mNotificationHandlerThread = new HandlerThread("MuzeiWallpaperService-Notification");
+        mNotificationHandlerThread.start();
+        mNotificationContentObserver = new ContentObserver(new Handler(mNotificationHandlerThread.getLooper())) {
+            @Override
+            public void onChange(final boolean selfChange, final Uri uri) {
+                NewWallpaperNotificationReceiver.maybeShowNewArtworkNotification(mContext);
+            }
+        };
+        mContext.getContentResolver().registerContentObserver(MuzeiContract.Artwork.CONTENT_URI,
+                true, mNotificationContentObserver);
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    public void unregisterContentObserver() {
+        mContext.getContentResolver().unregisterContentObserver(mNotificationContentObserver);
+        mNotificationHandlerThread.quitSafely();
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/wallpaper/WallpaperAnalytics.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wallpaper/WallpaperAnalytics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.wallpaper;
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
+
+import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import net.nurik.roman.muzei.BuildConfig;
+
+import org.greenrobot.eventbus.EventBus;
+
+/**
+ * LifecycleObserver responsible for sending analytics callbacks based on the state of the wallpaper
+ */
+public class WallpaperAnalytics implements LifecycleObserver {
+    private final Context mContext;
+
+    public WallpaperAnalytics(Context context) {
+        mContext = context;
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    public void registerDeviceType() {
+        FirebaseAnalytics.getInstance(mContext).setUserProperty("device_type", BuildConfig.DEVICE_TYPE);
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    public void triggerWallpaperCreated() {
+        FirebaseAnalytics.getInstance(mContext).logEvent("wallpaper_created", null);
+        EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(true));
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    public void triggerWallpaperDestroyed() {
+        FirebaseAnalytics.getInstance(mContext).logEvent("wallpaper_destroyed", null);
+        EventBus.getDefault().postSticky(new WallpaperActiveStateChangedEvent(false));
+    }
+}


### PR DESCRIPTION
Instead of having a large block of code in an `initialize()` block for `MuzeiWallpaperService` and a separate `activateWallpaper()` in `MuzeiWallpaperService.MuzeiWallpaperEngine`, take advantage of the [Lifecycle Architecture Component](https://developer.android.com/topic/libraries/architecture/lifecycle.html) to move each piece to separate `LifecycleObserver`s.