### PR TITLE
Ensure Muzei builds from the command line

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -37,6 +37,11 @@ android {
                 "\"${documentsAuthorityValue}\"")
     }
 
+    buildTypes {
+        publicBeta
+        publicDebug
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -17,8 +17,8 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile project(':api')
-    compile "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
+    implementation project(':api')
+    implementation "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
 }
 
 android {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -46,6 +46,11 @@ android {
         manifestPlaceholders = [api_version: versionProps['apiCode'].toInteger()]
     }
 
+    buildTypes {
+        publicBeta
+        publicDebug
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,14 +18,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def Properties versionProps = new Properties()
+Properties versionProps = new Properties()
 versionProps.load(new FileInputStream(file('../version.properties')))
 
 group = 'com.google.android.apps.muzei'
 version = versionProps['apiName']
 
 
-def Properties props = new Properties()
+Properties props = new Properties()
 props.load(new FileInputStream(file('../local.properties')))
 
 allprojects { ext."signing.keyId" = props["signing.keyId"] }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -33,7 +33,7 @@ allprojects { ext."signing.password" = props["signing.password"] }
 allprojects { ext."signing.secretKeyRingFile" = props["signing.secretKeyRingFile"] }
 
 dependencies {
-    compile "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
 }
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-alpha3'

--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -17,10 +17,10 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile "com.squareup.retrofit2:retrofit:2.1.0"
-    compile "com.squareup.retrofit2:converter-gson:2.1.0"
-    //compile "com.google.android.apps.muzei:muzei-api:+"
-    compile project(':api')
+    implementation "com.squareup.retrofit2:retrofit:2.1.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.1.0"
+    //implementation "com.google.android.apps.muzei:muzei-api:+"
+    implementation project(':api')
 }
 
 android {

--- a/example-watchface/build.gradle
+++ b/example-watchface/build.gradle
@@ -17,9 +17,9 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile "com.google.android.support:wearable:1.4.0"
-    //compile "com.google.android.apps.muzei:muzei-api:+"
-    compile project(':api')
+    implementation "com.google.android.support:wearable:1.4.0"
+    //implementation "com.google.android.apps.muzei:muzei-api:+"
+    implementation project(':api')
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.daemon=true
+org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx2048M

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
-    def Properties versionProps = new Properties()
+    Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))
 
     dexOptions.preDexLibraries true

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -87,27 +87,26 @@ android {
 }
 
 dependencies {
-    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
-    compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
-    compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-core:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-perf:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
+    implementation "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
+    implementation "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.google.firebase:firebase-core:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.google.firebase:firebase-perf:$rootProject.ext.googlePlayServicesVersion"
     // Only use crash reporting in release builds
-    releaseCompile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.twofortyfouram:android-plugin-api-for-locale:1.0.2"
-    compile "org.greenrobot:eventbus:3.0.0"
-    compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
-    compile "android.arch.lifecycle:runtime:1.0.0-alpha2"
+    releaseImplementation "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.twofortyfouram:android-plugin-api-for-locale:1.0.2"
+    implementation "org.greenrobot:eventbus:3.0.0"
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:design:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
+    implementation "android.arch.lifecycle:runtime:1.0.0-alpha2"
 
-    // :api is included as a transitive dependency from :android-client-common
-    // compile project(':api')
-    compile project(':android-client-common')
-    compile project(':source-featured-art')
-    compile project(':source-gallery')
+    implementation project(':api')
+    implementation project(':android-client-common')
+    implementation project(':source-featured-art')
+    implementation project(':source-gallery')
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -33,6 +33,11 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
     }
 
+    buildTypes {
+        publicBeta
+        publicDebug
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -17,9 +17,9 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile project(':api')
-    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
-    compile "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
+    implementation project(':api')
+    implementation "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
+    implementation "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
 }
 
 android {

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -17,14 +17,14 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile project(':api')
-    compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
-    compile "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
-    compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:percent:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
+    implementation project(':api')
+    implementation "com.squareup.okhttp3:okhttp:$rootProject.ext.okhttpVersion"
+    implementation "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:design:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:percent:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
 }
 
 android {

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -40,6 +40,11 @@ android {
         buildConfigField "String", "GALLERY_AUTHORITY", "\"${galleryAuthorityValue}\""
     }
 
+    buildTypes {
+        publicBeta
+        publicDebug
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -85,21 +85,23 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
-    provided "com.google.android.wearable:wearable:2.0.2"
-    compile "com.google.android.support:wearable:2.0.2"
+    implementation "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
+    compileOnly "com.google.android.wearable:wearable:2.0.2"
+    implementation "com.google.android.support:wearable:2.0.2"
     // Only used because wearable dependency depends on an old version of the Support Library
-    compile "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
-    compile "com.android.support:percent:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:percent:$rootProject.ext.supportLibraryVersion"
 
-    compile "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-core:$rootProject.ext.googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-perf:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.google.android.gms:play-services-wearable:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.google.firebase:firebase-core:$rootProject.ext.googlePlayServicesVersion"
+    implementation "com.google.firebase:firebase-perf:$rootProject.ext.googlePlayServicesVersion"
     // Only use crash reporting in release builds
-    releaseCompile "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
-    compile project(':android-client-common')
+    releaseImplementation "com.google.firebase:firebase-crash:$rootProject.ext.googlePlayServicesVersion"
+
+    implementation project(':api')
+    implementation project(':android-client-common')
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -21,7 +21,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
-    def Properties versionProps = new Properties()
+    Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))
 
     publishNonDefault true
@@ -41,9 +41,9 @@ android {
 
     signingConfigs {
         release {
-            def Properties localProps = new Properties()
+            Properties localProps = new Properties()
             localProps.load(new FileInputStream(file('../local.properties')))
-            def Properties keyProps = new Properties()
+            Properties keyProps = new Properties()
             if (localProps['keystore.props.file'] != null) {
                 keyProps.load(new FileInputStream(file(localProps['keystore.props.file'])))
             }

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -76,6 +76,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+
+    lintOptions {
+        // Needed until 3.0.0-alpha4 is released per https://issuetracker.google.com/issues/62318360
+        abortOnError false
+    }
+
 }
 
 dependencies {


### PR DESCRIPTION
With the move to Android Studio 3.0 and the [new Android Plugin](https://developer.android.com/studio/preview/features/new-android-plugin.html), a number of [migration steps](https://developer.android.com/studio/preview/features/new-android-plugin-migration.html) were required to get Muzei building from the command line.