### PR TITLE
Prevent the New Wallpaper notifications from showing a badge by default

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -359,6 +359,7 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
         NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL,
                 context.getString(R.string.notification_new_wallpaper_channel_name),
                 NotificationManager.IMPORTANCE_MIN);
+        channel.setShowBadge(false);
         notificationManager.createNotificationChannel(channel);
     }
 }


### PR DESCRIPTION
Users are very aware that their wallpaper changed (their background changed after all), so badging the Muzei app is unnecessary.