### PR TITLE
Improve integrations with the service's lifecycle

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.java
@@ -432,6 +432,7 @@ public class ArtDetailFragment extends Fragment
     public void onResume() {
         super.onResume();
         mConsecutiveLoadErrorCount = 0;
+        NewWallpaperNotificationReceiver.markNotificationRead(getContext());
     }
 
     @Override

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -123,8 +123,6 @@ public class MuzeiActivity extends AppCompatActivity
                     .setDuration(300);
             mFadeIn = false;
         }
-
-        NewWallpaperNotificationReceiver.markNotificationRead(this);
     }
 
     @Subscribe

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.java
@@ -83,6 +83,7 @@ public class MuzeiWallpaperService extends GLWallpaperService implements Lifecyc
                 public void onReceive(Context context, Intent intent) {
                     mLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
                     unregisterReceiver(this);
+                    mUnlockReceiver = null;
                 }
             };
             IntentFilter filter = new IntentFilter(Intent.ACTION_USER_UNLOCKED);

--- a/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
+++ b/main/src/main/java/com/google/android/apps/muzei/NewWallpaperNotificationReceiver.java
@@ -137,6 +137,10 @@ public class NewWallpaperNotificationReceiver extends BroadcastReceiver {
             lastArtwork.close();
         }
 
+        cancelNotification(context);
+    }
+
+    public static void cancelNotification(Context context) {
         NotificationManagerCompat nm = NotificationManagerCompat.from(context);
         nm.cancel(NOTIFICATION_ID);
     }

--- a/main/src/main/java/com/google/android/apps/muzei/wallpaper/NotificationUpdater.java
+++ b/main/src/main/java/com/google/android/apps/muzei/wallpaper/NotificationUpdater.java
@@ -59,5 +59,6 @@ public class NotificationUpdater implements LifecycleObserver {
     public void unregisterContentObserver() {
         mContext.getContentResolver().unregisterContentObserver(mNotificationContentObserver);
         mNotificationHandlerThread.quitSafely();
+        NewWallpaperNotificationReceiver.cancelNotification(mContext);
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
@@ -42,9 +42,12 @@ import android.view.View;
 import android.widget.RemoteViews;
 
 import com.google.android.apps.muzei.api.MuzeiContract;
+import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
 import com.google.android.apps.muzei.render.ImageUtil;
 
 import net.nurik.roman.muzei.R;
+
+import org.greenrobot.eventbus.EventBus;
 
 import java.io.FileNotFoundException;
 
@@ -96,7 +99,9 @@ public class AppWidgetUpdateTask extends AsyncTask<Void,Void,Boolean> {
                 : byline;
         Uri imageUri = ContentUris.withAppendedId(MuzeiContract.Artwork.CONTENT_URI,
                 artwork.getLong(artwork.getColumnIndex(BaseColumns._ID)));
-        boolean supportsNextArtwork = artwork.getInt(
+        WallpaperActiveStateChangedEvent e = EventBus.getDefault().getStickyEvent(
+                WallpaperActiveStateChangedEvent.class);
+        boolean supportsNextArtwork = e != null && e.isActive() && artwork.getInt(
                 artwork.getColumnIndex(MuzeiContract.Sources.COLUMN_NAME_SUPPORTS_NEXT_ARTWORK_COMMAND)) != 0;
         artwork.close();
 

--- a/main/src/main/java/com/google/android/apps/muzei/widget/WidgetUpdater.java
+++ b/main/src/main/java/com/google/android/apps/muzei/widget/WidgetUpdater.java
@@ -52,10 +52,15 @@ public class WidgetUpdater implements LifecycleObserver {
                 true, mWidgetContentObserver);
         mContext.getContentResolver().registerContentObserver(MuzeiContract.Sources.CONTENT_URI,
                 true, mWidgetContentObserver);
+        // Update the widget now that the wallpaper is active to enable the 'Next' button if supported
+        mWidgetContentObserver.onChange(true);
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     public void unregisterContentObserver() {
         mContext.getContentResolver().unregisterContentObserver(mWidgetContentObserver);
+        // Update the widget one last time to disable the 'Next' button until Muzei is reactivated
+        new AppWidgetUpdateTask(mContext, false)
+                .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 }


### PR DESCRIPTION
- Fix a crash when disabling Muzei after a reboot on Android N+ devices
- Ensure that the notification stays in sync with Muzei and is only shown when Muzei is active
- Hide the 'Next' button from the widget when Muzei is not active