### PR TITLE
Fix Gallery deletion/force logic for folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath ('com.google.firebase:firebase-plugins:1.1.0') {
             exclude group: 'com.google.guava', module: 'guava-jdk5'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 15 18:45:35 PDT 2017
+#Fri Jun 30 20:46:00 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GallerySettingsActivity.java
@@ -33,7 +33,6 @@ import android.content.OperationApplicationException;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.database.Cursor;
@@ -90,7 +89,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.Random;
 import java.util.Set;
 
 import static com.google.android.apps.muzei.gallery.GalleryArtSource.ACTION_PUBLISH_NEXT_GALLERY_ITEM;
@@ -99,7 +97,6 @@ import static com.google.android.apps.muzei.gallery.GalleryArtSource.EXTRA_FORCE
 public class GallerySettingsActivity extends AppCompatActivity
         implements LoaderManager.LoaderCallbacks<Cursor> {
     private static final String TAG = "GallerySettingsActivity";
-    private static final String DOCUMENTS_UI_PACKAGE_NAME = "com.android.documentsui";
     private static final String SHARED_PREF_NAME = "GallerySettingsActivity";
     private static final String SHOW_INTERNAL_STORAGE_MESSAGE = "show_internal_storage_message";
     private static final int REQUEST_CHOOSE_PHOTOS = 1;
@@ -488,22 +485,6 @@ public class GallerySettingsActivity extends AppCompatActivity
                     Set<Uri> selection = mMultiSelectionController.getSelection();
                     if (selection.size() > 0) {
                         Uri selectedUri = selection.iterator().next();
-                        // Check to see if it is tree URI, if so, force a random photo from the tree
-                        Cursor data = getContentResolver().query(selectedUri,
-                                new String[] { GalleryContract.ChosenPhotos.COLUMN_NAME_IS_TREE_URI,
-                                        GalleryContract.ChosenPhotos.COLUMN_NAME_URI },
-                                null, null, null);
-                        if (data != null && data.moveToNext()) {
-                            boolean isTreeUri = data.getInt(0) != 0;
-                            if (isTreeUri) {
-                                Uri treeUri = Uri.parse(data.getString(1));
-                                List<Uri> photoUris = getImagesFromTreeUri(treeUri, Integer.MAX_VALUE);
-                                selectedUri = photoUris.get(new Random().nextInt(photoUris.size()));
-                            }
-                        }
-                        if (data != null) {
-                            data.close();
-                        }
                         startService(
                                 new Intent(GallerySettingsActivity.this, GalleryArtSource.class)
                                         .setAction(ACTION_PUBLISH_NEXT_GALLERY_ITEM)


### PR DESCRIPTION
When forcing a folder, we should pick an image from that folder to force, rather than try to force the tree URI itself.

We now use the token of the artwork as the chosen photo URI: this allows us to correctly swap to another image when the folder is removed.