### PR TITLE
Better exception handling from ContentProviders

### DIFF
--- a/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
@@ -501,7 +501,7 @@ public class MuzeiContract {
                 }
                 for (Uri contentUri : contentUris) {
                     Uri artworkUri = contentResolver.insert(contentUri, values);
-                    try (OutputStream out = contentResolver.openOutputStream(artworkUri)) {
+                    try (OutputStream out = artworkUri != null ? contentResolver.openOutputStream(artworkUri) : null) {
                         if (out == null) {
                             continue;
                         }
@@ -532,7 +532,7 @@ public class MuzeiContract {
                 }
                 for (Uri contentUri : contentUris) {
                     Uri artworkUri = contentResolver.insert(contentUri, values);
-                    try (OutputStream out = contentResolver.openOutputStream(artworkUri)) {
+                    try (OutputStream out = artworkUri != null ? contentResolver.openOutputStream(artworkUri) : null) {
                         if (out == null) {
                             continue;
                         }

--- a/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/PhotoSetAsTargetActivity.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Intent;
-import android.database.SQLException;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -45,32 +44,32 @@ public class PhotoSetAsTargetActivity extends Activity {
 
         Uri photoUri = getIntent().getData();
 
-
-        try {
-            // Add the chosen photo
-            ContentValues values = new ContentValues();
-            values.put(GalleryContract.ChosenPhotos.COLUMN_NAME_URI, photoUri.toString());
-            Uri uri = getContentResolver().insert(GalleryContract.ChosenPhotos.CONTENT_URI, values);
-
-            // If adding the artwork succeeded, select the gallery source and publish the new image
-            Bundle bundle = new Bundle();
-            bundle.putString(FirebaseAnalytics.Param.ITEM_ID,
-                    new ComponentName(this, GalleryArtSource.class).flattenToShortString());
-            bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
-            FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
-            SourceManager.selectSource(this, new ComponentName(this, GalleryArtSource.class));
-
-            startService(new Intent(this, GalleryArtSource.class)
-                    .setAction(GalleryArtSource.ACTION_PUBLISH_NEXT_GALLERY_ITEM)
-                    .putExtra(GalleryArtSource.EXTRA_FORCE_URI, uri));
-
-            // Launch main activity
-            startActivity(Intent.makeMainActivity(new ComponentName(this, MuzeiActivity.class))
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
-        } catch (SQLException e) {
-            Log.e(TAG, "Unable to insert chosen artwork", e);
+        // Add the chosen photo
+        ContentValues values = new ContentValues();
+        values.put(GalleryContract.ChosenPhotos.COLUMN_NAME_URI, photoUri.toString());
+        Uri uri = getContentResolver().insert(GalleryContract.ChosenPhotos.CONTENT_URI, values);
+        if (uri == null) {
+            Log.e(TAG, "Unable to insert chosen artwork for " + photoUri);
             Toast.makeText(this, R.string.set_as_wallpaper_failed, Toast.LENGTH_SHORT).show();
+            finish();
+            return;
         }
+
+        // If adding the artwork succeeded, select the gallery source and publish the new image
+        Bundle bundle = new Bundle();
+        bundle.putString(FirebaseAnalytics.Param.ITEM_ID,
+                new ComponentName(this, GalleryArtSource.class).flattenToShortString());
+        bundle.putString(FirebaseAnalytics.Param.CONTENT_TYPE, "sources");
+        FirebaseAnalytics.getInstance(this).logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, bundle);
+        SourceManager.selectSource(this, new ComponentName(this, GalleryArtSource.class));
+
+        startService(new Intent(this, GalleryArtSource.class)
+                .setAction(GalleryArtSource.ACTION_PUBLISH_NEXT_GALLERY_ITEM)
+                .putExtra(GalleryArtSource.EXTRA_FORCE_URI, uri));
+
+        // Launch main activity
+        startActivity(Intent.makeMainActivity(new ComponentName(this, MuzeiActivity.class))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
         finish();
     }
 }

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtSource.java
@@ -476,7 +476,7 @@ public class GalleryArtSource extends MuzeiArtSource {
 
                 getContentResolver().insert(GalleryContract.MetadataCache.CONTENT_URI, values);
             } catch (ParseException|IOException|IllegalArgumentException|StackOverflowError
-                    |NullPointerException e) {
+                    |NullPointerException|SecurityException e) {
                 Log.w(TAG, "Couldn't read image metadata.", e);
             }
         }


### PR DESCRIPTION
Update the GalleryProvider and MuzeiProvider to better handle error cases without crashing Muzei. Namely, removing the use of SQLExceptions entirely and handling SecurityExceptions when fetching gallery image metadata.