### PR TITLE
Move inset of API 25 app shortcuts into the background itself

### DIFF
--- a/main/src/main/res/drawable-v25/ic_shortcut_artwork_info.xml
+++ b/main/src/main/res/drawable-v25/ic_shortcut_artwork_info.xml
@@ -15,12 +15,7 @@
   -->
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:bottom="2dp"
-        android:drawable="@drawable/ic_shortcut_background"
-        android:left="2dp"
-        android:right="2dp"
-        android:top="2dp" />
+    <item android:drawable="@drawable/ic_shortcut_background"/>
 
     <item android:drawable="@drawable/ic_shortcut_artwork_info_foreground" />
 </layer-list>

--- a/main/src/main/res/drawable-v25/ic_shortcut_background.xml
+++ b/main/src/main/res/drawable-v25/ic_shortcut_background.xml
@@ -14,9 +14,11 @@
   limitations under the License.
   -->
 
-<shape
+<inset
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="@color/shortcut_background" />
-    <size android:width="44dp" android:height="44dp" />
-</shape>
+    android:inset="2dp">
+    <shape android:shape="oval">
+        <solid android:color="@color/shortcut_background" />
+        <size android:width="44dp" android:height="44dp" />
+    </shape>
+</inset>


### PR DESCRIPTION
Rather than rely on each shortcut to add the inset, bake it into the background drawable itself.