### PR TITLE
Support "android.resource" type artwork

### DIFF
--- a/api/src/main/java/com/google/android/apps/muzei/api/Artwork.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/Artwork.java
@@ -381,6 +381,9 @@ public class Artwork {
          * permissions). To build a file-based content provider, see the
          * <a href="https://developer.android.com/reference/android/support/v4/content/FileProvider.html">FileProvider</a>
          * class in the Android support library.</li>
+         * <li><code>android.resource://...</code>. Resource URLs are recommended to be identified
+         * by resource type name and entry name instead of resource ID, to be more reliable after
+         * source app updates.</li>
          * <li><code>http://...</code> or <code>https://...</code>. These URLs must be
          * publicly accessible (i.e. not require authentication of any kind).</li>
          * </ul>

--- a/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
@@ -554,7 +554,7 @@ public class MuzeiContract {
                 }
 
                 InputStream in = null;
-                if ("content".equals(scheme)) {
+                if ("content".equals(scheme) || "android.resource".equals(scheme)) {
                     try {
                         in = contentResolver.openInputStream(uri);
                     } catch (SecurityException e) {

--- a/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.java
@@ -453,6 +453,7 @@ public class MuzeiContract {
              *
              * <ul>
              * <li><code>content://...</code>.</li>
+             * <li><code>android.resource://...</code>.</li>
              * <li><code>file://...</code>.</li>
              * <li><code>file:///android_asset/...</code>.</li>
              * <li><code>http://...</code> or <code>https://...</code>.</li>

--- a/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/sync/DownloadArtworkTask.java
@@ -122,7 +122,7 @@ public class DownloadArtworkTask extends AsyncTask<Void, Void, Boolean> {
         }
 
         InputStream in = null;
-        if ("content".equals(scheme)) {
+        if ("content".equals(scheme) || "android.resource".equals(scheme)) {
             try {
                 in = context.getContentResolver().openInputStream(uri);
             } catch (SecurityException e) {


### PR DESCRIPTION
Maybe someone(like me) want to develop a Muzei source that provide a set of images, we can let Muzei support the resources artwork.

With doing that, in `MuzeiArtSource.onUpdate`, we can publish an artwork with image uri in a format of `android.resource://<packageName>/<resourceType>/<resourceEntryName>` or `android.resource://<packageName>/<resourceId>`.