### PR TITLE
Update Support Library to 26.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     buildToolsVersion = "26.0.0"
     targetSdkVersion = 25
 
-    supportLibraryVersion = "26.0.0"
+    supportLibraryVersion = "26.0.1"
     googlePlayServicesVersion = "11.0.4"
     okhttpVersion = "3.8.1"
     picassoVersion = "2.5.2"


### PR DESCRIPTION
Fixes crashes when using FontCompat 26.0.0 as described in
https://developer.android.com/topic/libraries/support-library/revisions.html#26-0-1