### PR TITLE
Fix issues when sources target API 26

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -30,6 +30,11 @@
     <string name="action_activate">Activate</string>
     <string name="action_settings">Customize</string>
     <string name="action_source_settings">Customize source</string>
+    <string name="action_source_target_too_high_title">This source is disabled</string>
+    <string name="action_source_target_too_high_message">Muzei\'s API is not yet compatible with apps such as this one that target Android 8.0 (API 26).</string>
+    <string name="action_source_target_too_high_send_feedback">Send %s feedback</string>
+    <string name="action_source_target_too_high_learn_more">Learn more</string>
+    <string name="action_source_target_too_high_dismiss">Got it</string>
 
     <string name="contentdesc_overflow">More options</string>
     <string name="error_view_details">Couldn\'t view artwork details.</string>


### PR DESCRIPTION
The current Muzei API does not support targeting API 26 (on either Muzei
or the source's side). With source's potentially targeting API 26 without
testing their Muzei integrations, Muzei should defensively switch away
from those sources and warn users that they are unable to use that
source.

Does some minor Lint fixing of the SettingsChooseSourceFragment as well.

Caused by java.lang.IllegalStateException: Not allowed to start service Intent { act=com.google.android.apps.muzei.api.action.SUBSCRIBE cmp=com.backdrops.wallpapers/.muzei.ArtSource (has extras) }: app is in background uid null
android.app.ContextImpl.startServiceCommon (ContextImpl.java:1505)
android.app.ContextImpl.startService (ContextImpl.java:1461)
android.content.ContextWrapper.startService (ContextWrapper.java:644)
com.google.android.apps.muzei.SourceManager.unsubscribeToSelectedSource (SourceManager.java:273)
com.google.android.apps.muzei.SourceManager.unsubscribeToSelectedSource (SourceManager.java:93)
java.lang.reflect.Method.invoke (Method.java)
android.arch.lifecycle.ReflectiveGenericLifecycleObserver.invokeCallback (ReflectiveGenericLifecycleObserver.java:69)
android.arch.lifecycle.ReflectiveGenericLifecycleObserver.invokeMethodsForEvent (ReflectiveGenericLifecycleObserver.java:53)
android.arch.lifecycle.ReflectiveGenericLifecycleObserver.invokeCallbacks (ReflectiveGenericLifecycleObserver.java:60)
android.arch.lifecycle.ReflectiveGenericLifecycleObserver.onStateChanged (ReflectiveGenericLifecycleObserver.java:45)
android.arch.lifecycle.LifecycleRegistry$ObserverWithState.sync (LifecycleRegistry.java:209)
android.arch.lifecycle.LifecycleRegistry.handleLifecycleEvent (LifecycleRegistry.java:102)
com.google.android.apps.muzei.MuzeiWallpaperService.onDestroy (MuzeiWallpaperService.java:104)
android.app.ActivityThread.handleStopService (ActivityThread.java:3569)
android.app.ActivityThread.-wrap26 ()
android.app.ActivityThread$H.handleMessage (ActivityThread.java:1703)
android.os.Handler.dispatchMessage (Handler.java:105)
android.os.Looper.loop (Looper.java:164)
android.app.ActivityThread.main (ActivityThread.java:6541)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:240)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:767)