### PR TITLE
Update library versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta2'
@@ -31,9 +29,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
+        google()
     }
 }
 
@@ -43,7 +39,9 @@ ext {
     targetSdkVersion = 25
 
     supportLibraryVersion = "26.0.1"
-    googlePlayServicesVersion = "11.0.4"
+    lifecycleVersion = "1.0.0-alpha9"
+    googlePlayServicesVersion = "11.2.0"
+    wearableVersion = "2.0.4"
     okhttpVersion = "3.8.1"
     picassoVersion = "2.5.2"
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation "com.android.support:design:$rootProject.ext.supportLibraryVersion"
     implementation "com.android.support:customtabs:$rootProject.ext.supportLibraryVersion"
     implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
-    implementation "android.arch.lifecycle:runtime:1.0.0-alpha7"
+    implementation "android.arch.lifecycle:runtime:$rootProject.ext.lifecycleVersion"
 
     implementation project(':api')
     implementation project(':android-client-common')

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -85,8 +85,8 @@ android {
 dependencies {
     implementation "com.android.support:support-compat:$rootProject.ext.supportLibraryVersion"
     implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
-    compileOnly "com.google.android.wearable:wearable:2.0.3"
-    implementation "com.google.android.support:wearable:2.0.3"
+    compileOnly "com.google.android.wearable:wearable:$rootProject.ext.wearableVersion"
+    implementation "com.google.android.support:wearable:$rootProject.ext.wearableVersion"
     // Only used because wearable dependency depends on an old version of the Support Library
     implementation "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
     implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"


### PR DESCRIPTION
- Lifecycle to 1.0.0-alpha9
- Google Play services to 11.2.0
- Wearable to 2.0.4

And switches us to use google() for the repository name and centralizes
all versions to the root build.gradle file.