### PR TITLE
Update to Android plugin 3.0.0-beta7

### DIFF
--- a/android-client-common/build.gradle
+++ b/android-client-common/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -37,7 +37,6 @@ dependencies {
 }
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 11

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
         classpath 'com.google.gms:google-services:3.1.0'
         classpath 'com.google.firebase:firebase-plugins:1.1.1'
     }
@@ -35,7 +35,6 @@ allprojects {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.2"
     targetSdkVersion = 25
 
     supportLibraryVersion = "26.1.0"

--- a/example-source-500px/build.gradle
+++ b/example-source-500px/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/example-watchface/build.gradle
+++ b/example-watchface/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 21

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -21,7 +21,6 @@ project.archivesBaseName = "muzei"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))

--- a/source-featured-art/build.gradle
+++ b/source-featured-art/build.gradle
@@ -26,7 +26,6 @@ android {
     resourcePrefix 'featuredart_'
 
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 18

--- a/source-gallery/build.gradle
+++ b/source-gallery/build.gradle
@@ -35,7 +35,6 @@ dependencies {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 19

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'com.google.firebase.firebase-perf'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))


### PR DESCRIPTION
Remove no longer required buildToolsVersion field as per
https://androidstudio.googleblog.com/2017/10/android-studio-30-beta-7-is-now.html