### PR TITLE
Fix supportsNextArtwork

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
+++ b/main/src/main/java/com/google/android/apps/muzei/SourceSubscriberService.java
@@ -79,6 +79,7 @@ public class SourceSubscriberService extends IntentService {
 
         source.description = state.getDescription();
         source.wantsNetworkAvailable = state.getWantsNetworkAvailable();
+        source.supportsNextArtwork = false;
         source.commands = new ArrayList<>();
         int numSourceActions = state.getNumUserCommands();
         for (int i = 0; i < numSourceActions; i++) {


### PR DESCRIPTION
In cases where a source moves from supporting 'Next Artwork' to not supporting it, make sure the Source is also updated.