### PR TITLE
Ensure decoded images are presented in ARGB_8888, not RGBA_F16

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
+++ b/main/src/main/java/com/google/android/apps/muzei/render/BitmapRegionLoader.java
@@ -79,10 +79,14 @@ public class BitmapRegionLoader {
      * if <code>inBitmap</code> is given, a sub-bitmap might be returned.
      */
     public synchronized Bitmap decodeRegion(Rect rect, Options options) {
+        if (options == null) {
+            options = new Options();
+        }
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888;
         int unsampledInBitmapWidth = -1;
         int unsampledInBitmapHeight = -1;
-        int sampleSize = Math.max(1, options != null ? options.inSampleSize : 1);
-        if (options != null && options.inBitmap != null) {
+        int sampleSize = Math.max(1, options.inSampleSize);
+        if (options.inBitmap != null) {
             unsampledInBitmapWidth = options.inBitmap.getWidth() * sampleSize;
             unsampledInBitmapHeight = options.inBitmap.getHeight() * sampleSize;
         }
@@ -116,7 +120,7 @@ public class BitmapRegionLoader {
             return null;
         }
 
-        if (options != null && options.inBitmap != null &&
+        if (options.inBitmap != null &&
                 ((mTempRect.width() != unsampledInBitmapWidth
                         || mTempRect.height() != unsampledInBitmapHeight))) {
             // Need to extract the sub-bitmap
@@ -136,7 +140,7 @@ public class BitmapRegionLoader {
                     bitmap, 0, 0,
                     bitmap.getWidth(), bitmap.getHeight(),
                     mRotateMatrix, true);
-            if ((options == null || bitmap != options.inBitmap) && bitmap != rotatedBitmap) {
+            if (bitmap != options.inBitmap && bitmap != rotatedBitmap) {
                 bitmap.recycle();
             }
             bitmap = rotatedBitmap;


### PR DESCRIPTION
Renderscript does not support RGBA_F16 images as might be decoded from JPEG images with an embedded color profile on API 26+ devices. By having BitmapRegionLoader always set the inPreferredConfig to ARGB_8888, we ensure that the resulting images can work with Renderscript.

Exception android.renderscript.RSInvalidStateException: Bad bitmap type: RGBA_F16
android.renderscript.Allocation.elementFromBitmap (Allocation.java:2767)
android.renderscript.Allocation.typeFromBitmap (Allocation.java:2772)
android.renderscript.Allocation.createFromBitmap (Allocation.java:2811)
android.renderscript.Allocation.createFromBitmap (Allocation.java:3063)
com.google.android.apps.muzei.util.ImageBlurrer.<init> (ImageBlurrer.java:43)
com.google.android.apps.muzei.render.MuzeiBlurRenderer$GLPictureSet.load (MuzeiBlurRenderer.java:387)
com.google.android.apps.muzei.render.MuzeiBlurRenderer.setAndConsumeBitmapRegionLoader (MuzeiBlurRenderer.java:262)
com.google.android.apps.muzei.render.RenderController$3$1.run (RenderController.java:108)
com.google.android.apps.muzei.render.GLTextureView$GLThread.guardedRun (GLTextureView.java:1238)
com.google.android.apps.muzei.render.GLTextureView$GLThread.run (GLTextureView.java:1015)