### PR TITLE
Allow onTryUpdate throwing RetryException to increment retry attempts

### DIFF
--- a/api/src/main/java/com/google/android/apps/muzei/api/RemoteMuzeiArtSource.java
+++ b/api/src/main/java/com/google/android/apps/muzei/api/RemoteMuzeiArtSource.java
@@ -107,13 +107,12 @@ public abstract class RemoteMuzeiArtSource extends MuzeiArtSource {
                 throw new RetryException();
             }
 
-            // In anticipation of update success, reset update attempt
-            // Any alarms will be cleared before onUpdate is called
-            sp.edit().remove(PREF_RETRY_ATTEMPT).apply();
-            setWantsNetworkAvailable(false);
-
             // Attempt an update
             onTryUpdate(reason);
+
+            // No RetryException, so declare success and reset update attempt
+            sp.edit().remove(PREF_RETRY_ATTEMPT).apply();
+            setWantsNetworkAvailable(false);
 
         } catch (RetryException e) {
             Log.w(TAG, "Error fetching, scheduling retry, id=" + mName);


### PR DESCRIPTION
Previously, the exponential backoff provided by RetryException only applies in cases where the network wasn't connected. Update the contract so that we'll also exponentially back off if onTryUpdate throws a RetryException.

This helps in cases such as #493 