### PR TITLE
Restrict widget image's size to the screen size

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
+++ b/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.java
@@ -123,10 +123,10 @@ public class AppWidgetUpdateTask extends AsyncTask<ArtworkSource,Void,Boolean> {
             Bundle extras = appWidgetManager.getAppWidgetOptions(widgetId);
             int widgetWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
                     extras.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH), displayMetrics);
-            widgetWidth = Math.max(widgetWidth, minWidgetSize);
+            widgetWidth = Math.max(Math.min(widgetWidth, displayMetrics.widthPixels), minWidgetSize);
             int widgetHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
                     extras.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT), displayMetrics);
-            widgetHeight = Math.max(widgetHeight, minWidgetSize);
+            widgetHeight = Math.max(Math.min(widgetHeight, displayMetrics.heightPixels), minWidgetSize);
             RemoteViews remoteViews = createRemoteViews(imageUri, contentDescription, launchPendingIntent,
                     nextArtworkPendingIntent, supportsNextArtwork, widgetWidth, widgetHeight);
             if (remoteViews == null) {


### PR DESCRIPTION
Widgets are limited to ~1.5x the screen size in memory and that's big enough for our needs.

Exception java.lang.RuntimeException: An error occurred while executing doInBackground()
Caused by java.lang.IllegalArgumentException: RemoteViews for widget update exceeds maximum bitmap memory usage (used: 12916836, max: 12441600)
android.os.Parcel.readException (Parcel.java:1688)
android.os.Parcel.readException (Parcel.java:1637)
com.android.internal.appwidget.IAppWidgetService$Stub$Proxy.updateAppWidgetIds (IAppWidgetService.java:647)
android.appwidget.AppWidgetManager.updateAppWidget (AppWidgetManager.java:474)
android.appwidget.AppWidgetManager.updateAppWidget (AppWidgetManager.java:547)
com.google.android.apps.muzei.widget.AppWidgetUpdateTask.doInBackground (AppWidgetUpdateTask.java:146)
com.google.android.apps.muzei.widget.AppWidgetUpdateTask.doInBackground (AppWidgetUpdateTask.java:57)
android.os.AsyncTask$2.call (AsyncTask.java:306)
java.util.concurrent.FutureTask.run (FutureTask.java:237)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1133)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:607)
java.lang.Thread.run (Thread.java:761)