### PR TITLE
Move Muzei to using Bottom Nav

### DIFF
--- a/android-client-common/src/main/res/values/colors.xml
+++ b/android-client-common/src/main/res/values/colors.xml
@@ -16,7 +16,7 @@
 
 <resources>
     <color name="theme_primary">#3c6caf</color>
-    <color name="theme_accent">#f2be19</color>
+    <color name="theme_accent">#fff</color>
 
     <color name="notification">@color/theme_primary</color>
 </resources>

--- a/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.java
@@ -19,7 +19,6 @@ package com.google.android.apps.muzei;
 import android.arch.lifecycle.Observer;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -51,7 +50,7 @@ import com.google.android.apps.muzei.notifications.NewWallpaperNotificationRecei
 import com.google.android.apps.muzei.room.Artwork;
 import com.google.android.apps.muzei.room.MuzeiDatabase;
 import com.google.android.apps.muzei.room.Source;
-import com.google.android.apps.muzei.settings.SettingsActivity;
+import com.google.android.apps.muzei.settings.AboutActivity;
 import com.google.android.apps.muzei.sync.TaskQueueService;
 import com.google.android.apps.muzei.util.AnimatedMuzeiLoadingSpinnerView;
 import com.google.android.apps.muzei.util.CheatSheet;
@@ -173,7 +172,6 @@ public class ArtDetailFragment extends Fragment {
             R.id.source_action_10,
     };
     private View mChromeContainerView;
-    private View mStatusBarScrimView;
     private View mMetadataView;
     private View mLoadingContainerView;
     private View mLoadErrorContainerView;
@@ -207,18 +205,9 @@ public class ArtDetailFragment extends Fragment {
     public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         // Ensure we have the latest insets
         view.requestFitSystemWindows();
-        mStatusBarScrimView = view.findViewById(R.id.statusbar_scrim);
 
         mChromeContainerView.setBackground(ScrimUtil.makeCubicGradientScrimDrawable(
                 0xaa000000, 8, Gravity.BOTTOM));
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            mStatusBarScrimView.setVisibility(View.GONE);
-            mStatusBarScrimView = null;
-        } else {
-            mStatusBarScrimView.setBackground(ScrimUtil.makeCubicGradientScrimDrawable(
-                    0x44000000, 8, Gravity.TOP));
-        }
 
         mMetadataView = view.findViewById(R.id.metadata);
 
@@ -243,21 +232,6 @@ public class ArtDetailFragment extends Fragment {
                                         }
                                     }
                                 });
-
-                        if (mStatusBarScrimView != null) {
-                            mStatusBarScrimView.setVisibility(View.VISIBLE);
-                            mStatusBarScrimView.animate()
-                                    .alpha(visible ? 1f : 0f)
-                                    .setDuration(200)
-                                    .withEndAction(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            if (!visible) {
-                                                mStatusBarScrimView.setVisibility(View.GONE);
-                                            }
-                                        }
-                                    });
-                        }
                     }
                 });
 
@@ -288,9 +262,9 @@ public class ArtDetailFragment extends Fragment {
                 }
 
                 switch (menuItem.getItemId()) {
-                    case R.id.action_settings:
-                        FirebaseAnalytics.getInstance(context).logEvent("settings_open", null);
-                        startActivity(new Intent(context, SettingsActivity.class));
+                    case R.id.action_about:
+                        FirebaseAnalytics.getInstance(context).logEvent("about_open", null);
+                        startActivity(new Intent(context, AboutActivity.class));
                         return true;
                 }
                 return false;
@@ -331,7 +305,7 @@ public class ArtDetailFragment extends Fragment {
                 new PanScaleProxyView.OnOtherGestureListener() {
                     @Override
                     public void onSingleTapUp() {
-                        showHideChrome((mContainerView.getSystemUiVisibility()
+                        showHideChrome((getActivity().getWindow().getDecorView().getSystemUiVisibility()
                                 & View.SYSTEM_UI_FLAG_LOW_PROFILE) != 0);
                     }
 
@@ -423,7 +397,7 @@ public class ArtDetailFragment extends Fragment {
                     | View.SYSTEM_UI_FLAG_FULLSCREEN
                     | View.SYSTEM_UI_FLAG_IMMERSIVE;
         }
-        mContainerView.setSystemUiVisibility(flags);
+        getActivity().getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 
     @Subscribe

--- a/main/src/main/java/com/google/android/apps/muzei/MainFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MainFragment.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.design.widget.BottomNavigationView;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.OnApplyWindowInsetsListener;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.WindowInsetsCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.google.android.apps.muzei.settings.SettingsAdvancedFragment;
+import com.google.android.apps.muzei.settings.SettingsChooseSourceFragment;
+import com.google.android.apps.muzei.util.ScrimUtil;
+
+import net.nurik.roman.muzei.R;
+
+/**
+ * Fragment which controls the main view of the Muzei app and handles the bottom navigation
+ * between various screens.
+ */
+public class MainFragment extends Fragment implements SettingsChooseSourceFragment.Callbacks {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull final LayoutInflater inflater, @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.main_fragment, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
+        // Set up the action bar
+        final View actionBarContainer = view.findViewById(R.id.action_bar_container);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            actionBarContainer.setBackground(ScrimUtil.makeCubicGradientScrimDrawable(
+                    0x44000000, 8, Gravity.TOP));
+        }
+        final Toolbar toolbar = view.findViewById(R.id.toolbar);
+        AppCompatActivity activity = (AppCompatActivity) getActivity();
+        if (activity != null) {
+            activity.setSupportActionBar(toolbar);
+            activity.getSupportActionBar().setDisplayShowTitleEnabled(false);
+        }
+
+        // Set up the container for the child fragments
+        final View container = view.findViewById(R.id.container);
+        if (savedInstanceState == null) {
+            getChildFragmentManager().beginTransaction()
+                    .replace(R.id.container, new ArtDetailFragment())
+                    .commit();
+        }
+
+        // Set up the bottom nav
+        final BottomNavigationView bottomNavigationView = view.findViewById(R.id.bottom_nav);
+        bottomNavigationView.setOnNavigationItemSelectedListener(
+                new BottomNavigationView.OnNavigationItemSelectedListener() {
+                    @Override
+                    public boolean onNavigationItemSelected(@NonNull final MenuItem item) {
+                        switch (item.getItemId()) {
+                            case R.id.main_art_details:
+                                getChildFragmentManager().beginTransaction()
+                                        .replace(R.id.container, new ArtDetailFragment())
+                                        .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                                        .commit();
+                                return true;
+                            case R.id.main_choose_source:
+                                getChildFragmentManager().beginTransaction()
+                                        .replace(R.id.container, new SettingsChooseSourceFragment())
+                                        .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                                        .commit();
+                                return true;
+                            case R.id.main_effects:
+                                getChildFragmentManager().beginTransaction()
+                                        .replace(R.id.container, new SettingsAdvancedFragment())
+                                        .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                                        .commit();
+                                return true;
+                            default:
+                                return false;
+                        }
+                    }
+                });
+        bottomNavigationView.setOnNavigationItemReselectedListener(
+                new BottomNavigationView.OnNavigationItemReselectedListener() {
+                    @Override
+                    public void onNavigationItemReselected(@NonNull final MenuItem item) {
+                        if (item.getItemId() == R.id.main_art_details) {
+                            getActivity().getWindow().getDecorView()
+                                    .setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE
+                                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+                                            | View.SYSTEM_UI_FLAG_IMMERSIVE
+                                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                            | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+                        }
+                    }
+                });
+
+        // Send the correct window insets to each view
+        ViewCompat.setOnApplyWindowInsetsListener(view, new OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsetsCompat onApplyWindowInsets(final View v, final WindowInsetsCompat insets) {
+                // Ensure the action bar container gets the appropriate insets
+                ViewCompat.dispatchApplyWindowInsets(actionBarContainer,
+                        insets.replaceSystemWindowInsets(insets.getSystemWindowInsetLeft(),
+                                insets.getSystemWindowInsetTop(),
+                                insets.getSystemWindowInsetRight(),
+                                0));
+                ViewCompat.dispatchApplyWindowInsets(container,
+                        insets.replaceSystemWindowInsets(insets.getSystemWindowInsetLeft(),
+                                0,
+                                insets.getSystemWindowInsetRight(),
+                                0));
+                ViewCompat.dispatchApplyWindowInsets(bottomNavigationView,
+                        insets.replaceSystemWindowInsets(insets.getSystemWindowInsetLeft(),
+                                0,
+                                insets.getSystemWindowInsetRight(),
+                                insets.getSystemWindowInsetBottom()));
+                return insets;
+            }
+        });
+
+        // Listen for visibility changes to know when to hide our views
+        view.setOnSystemUiVisibilityChangeListener(
+                new View.OnSystemUiVisibilityChangeListener() {
+                    @Override
+                    public void onSystemUiVisibilityChange(int vis) {
+                        final boolean visible = (vis & View.SYSTEM_UI_FLAG_LOW_PROFILE) == 0;
+
+                        actionBarContainer.setVisibility(View.VISIBLE);
+                        actionBarContainer.animate()
+                                .alpha(visible ? 1f : 0f)
+                                .setDuration(200)
+                                .withEndAction(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        if (!visible) {
+                                            actionBarContainer.setVisibility(View.GONE);
+                                        }
+                                    }
+                                });
+
+                        bottomNavigationView.setVisibility(View.VISIBLE);
+                        bottomNavigationView.animate()
+                                .alpha(visible ? 1f : 0f)
+                                .setDuration(200)
+                                .withEndAction(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        if (!visible) {
+                                            bottomNavigationView.setVisibility(View.GONE);
+                                        }
+                                    }
+                                });
+                    }
+                });
+
+    }
+
+    @Override
+    public void onRequestCloseActivity() {
+        BottomNavigationView bottomNavigationView = getView().findViewById(R.id.bottom_nav);
+        bottomNavigationView.setSelectedItemId(R.id.main_art_details);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        AppCompatActivity activity = (AppCompatActivity) getActivity();
+        if (activity != null) {
+            activity.setSupportActionBar(null);
+        }
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/MainFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MainFragment.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomNavigationView;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.OnApplyWindowInsetsListener;
 import android.support.v4.view.ViewCompat;
@@ -44,7 +45,22 @@ import net.nurik.roman.muzei.R;
  * Fragment which controls the main view of the Muzei app and handles the bottom navigation
  * between various screens.
  */
-public class MainFragment extends Fragment implements SettingsChooseSourceFragment.Callbacks {
+public class MainFragment extends Fragment implements FragmentManager.OnBackStackChangedListener,
+        SettingsChooseSourceFragment.Callbacks {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getChildFragmentManager().addOnBackStackChangedListener(this);
+    }
+
+    @Override
+    public void onBackStackChanged() {
+        if (getChildFragmentManager().getBackStackEntryCount() == 0) {
+            BottomNavigationView bottomNavigationView = getView().findViewById(R.id.bottom_nav);
+            bottomNavigationView.setSelectedItemId(R.id.main_art_details);
+        }
+    }
+
     @Nullable
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
@@ -88,14 +104,20 @@ public class MainFragment extends Fragment implements SettingsChooseSourceFragme
                                         .commit();
                                 return true;
                             case R.id.main_choose_source:
+                                getChildFragmentManager().popBackStack("main",
+                                        FragmentManager.POP_BACK_STACK_INCLUSIVE);
                                 getChildFragmentManager().beginTransaction()
                                         .replace(R.id.container, new SettingsChooseSourceFragment())
+                                        .addToBackStack("main")
                                         .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                                         .commit();
                                 return true;
                             case R.id.main_effects:
+                                getChildFragmentManager().popBackStack("main",
+                                        FragmentManager.POP_BACK_STACK_INCLUSIVE);
                                 getChildFragmentManager().beginTransaction()
                                         .replace(R.id.container, new SettingsAdvancedFragment())
+                                        .addToBackStack("main")
                                         .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                                         .commit();
                                 return true;
@@ -195,5 +217,11 @@ public class MainFragment extends Fragment implements SettingsChooseSourceFragme
         if (activity != null) {
             activity.setSupportActionBar(null);
         }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        getChildFragmentManager().removeOnBackStackChangedListener(this);
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -50,8 +50,10 @@ public class MuzeiActivity extends AppCompatActivity
                 | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
 
         if (savedInstanceState == null) {
+            Fragment currentFragment = getCurrentFragment();
             getSupportFragmentManager().beginTransaction()
-                    .add(R.id.container, getCurrentFragment())
+                    .add(R.id.container, currentFragment)
+                    .setPrimaryNavigationFragment(currentFragment)
                     .commit();
             mFadeIn = true;
         }
@@ -82,8 +84,10 @@ public class MuzeiActivity extends AppCompatActivity
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
         if (TutorialFragment.PREF_SEEN_TUTORIAL.equals(key)) {
+            MainFragment fragment = new MainFragment();
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, new MainFragment())
+                    .replace(R.id.container, fragment)
+                    .setPrimaryNavigationFragment(fragment)
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                     .commitAllowingStateLoss();
         }
@@ -102,8 +106,10 @@ public class MuzeiActivity extends AppCompatActivity
         super.onPostResume();
 
         if (mWallpaperActiveStateChanged) {
+            Fragment currentFragment = getCurrentFragment();
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, getCurrentFragment())
+                    .replace(R.id.container, currentFragment)
+                    .setPrimaryNavigationFragment(currentFragment)
                     .commit();
             mWallpaperActiveStateChanged = false;
         }

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiActivity.java
@@ -68,7 +68,7 @@ public class MuzeiActivity extends AppCompatActivity
             final SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
             if (sp.getBoolean(TutorialFragment.PREF_SEEN_TUTORIAL, false)) {
                 // The wallpaper is active and they've seen the tutorial
-                return new ArtDetailFragment();
+                return new MainFragment();
             } else {
                 // They need to see the tutorial after activating Muzei for the first time
                 return new TutorialFragment();
@@ -83,7 +83,7 @@ public class MuzeiActivity extends AppCompatActivity
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
         if (TutorialFragment.PREF_SEEN_TUTORIAL.equals(key)) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, new ArtDetailFragment())
+                    .replace(R.id.container, new MainFragment())
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                     .commitAllowingStateLoss();
         }

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsActivity.java
@@ -17,12 +17,6 @@
 package com.google.android.apps.muzei.settings;
 
 import android.animation.ObjectAnimator;
-import android.content.ActivityNotFoundException;
-import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -30,19 +24,15 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.android.apps.muzei.event.WallpaperActiveStateChangedEvent;
 import com.google.android.apps.muzei.render.MuzeiRendererFragment;
-import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.nurik.roman.muzei.R;
 
@@ -71,8 +61,6 @@ public class SettingsActivity extends AppCompatActivity
             SettingsChooseSourceFragment.class,
             SettingsAdvancedFragment.class,
     };
-
-    private static final String PLAY_STORE_PACKAGE_NAME = "com.android.vending";
 
     private int mStartSection = START_SECTION_SOURCE;
 
@@ -186,51 +174,6 @@ public class SettingsActivity extends AppCompatActivity
         });
 
         sectionSpinner.setSelection(mStartSection);
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-        getMenuInflater().inflate(R.menu.settings, menu);
-        return true;
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_get_more_sources:
-                FirebaseAnalytics.getInstance(SettingsActivity.this).logEvent("more_sources_open", null);
-                try {
-                    Intent playStoreIntent = new Intent(Intent.ACTION_VIEW,
-                            Uri.parse("http://play.google.com/store/search?q=Muzei&c=apps"))
-                            .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
-                    preferPackageForIntent(SettingsActivity.this,
-                            playStoreIntent, PLAY_STORE_PACKAGE_NAME);
-                    startActivity(playStoreIntent);
-                } catch (ActivityNotFoundException activityNotFoundException1) {
-                    Toast.makeText(SettingsActivity.this,
-                            R.string.play_store_not_found, Toast.LENGTH_LONG).show();
-                }
-                return true;
-
-            case R.id.action_about:
-                FirebaseAnalytics.getInstance(SettingsActivity.this).logEvent("about_open", null);
-                startActivity(new Intent(SettingsActivity.this, AboutActivity.class));
-                return true;
-
-            default:
-                return super.onOptionsItemSelected(item);
-        }
-    }
-
-    public static void preferPackageForIntent(Context context, Intent intent, String packageName) {
-        PackageManager pm = context.getPackageManager();
-        for (ResolveInfo resolveInfo : pm.queryIntentActivities(intent, 0)) {
-            if (resolveInfo.activityInfo.packageName.equals(packageName)) {
-                intent.setPackage(packageName);
-                break;
-            }
-        }
     }
 
     @Override

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsAdvancedFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsAdvancedFragment.java
@@ -53,10 +53,16 @@ public class SettingsAdvancedFragment extends Fragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
-        View rootView = inflater.inflate(R.layout.settings_advanced_fragment, container, false);
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.settings_advanced_fragment, container, false);
+    }
 
-        mBlurSeekBar = rootView.findViewById(R.id.blur_amount);
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        // Ensure we have the latest insets
+        view.requestFitSystemWindows();
+
+        mBlurSeekBar = view.findViewById(R.id.blur_amount);
         mBlurSeekBar.setProgress(Prefs.getSharedPreferences(getContext())
                 .getInt(Prefs.PREF_BLUR_AMOUNT, MuzeiBlurRenderer.DEFAULT_BLUR));
         mBlurSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -77,7 +83,7 @@ public class SettingsAdvancedFragment extends Fragment {
             }
         });
 
-        mDimSeekBar = rootView.findViewById(R.id.dim_amount);
+        mDimSeekBar = view.findViewById(R.id.dim_amount);
         mDimSeekBar.setProgress(Prefs.getSharedPreferences(getContext())
                 .getInt(Prefs.PREF_DIM_AMOUNT, MuzeiBlurRenderer.DEFAULT_MAX_DIM));
         mDimSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -98,7 +104,7 @@ public class SettingsAdvancedFragment extends Fragment {
             }
         });
 
-        mGreySeekBar = rootView.findViewById(R.id.grey_amount);
+        mGreySeekBar = view.findViewById(R.id.grey_amount);
         mGreySeekBar.setProgress(Prefs.getSharedPreferences(getContext())
                 .getInt(Prefs.PREF_GREY_AMOUNT, MuzeiBlurRenderer.DEFAULT_GREY));
         mGreySeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -118,7 +124,7 @@ public class SettingsAdvancedFragment extends Fragment {
             public void onStopTrackingTouch(SeekBar seekBar) {
             }
         });
-        CheckBox mBlurOnLockScreenCheckBox = rootView.findViewById(
+        CheckBox mBlurOnLockScreenCheckBox = view.findViewById(
                 R.id.blur_on_lockscreen_checkbox);
         mBlurOnLockScreenCheckBox.setOnCheckedChangeListener(
                 new CompoundButton.OnCheckedChangeListener() {
@@ -132,7 +138,6 @@ public class SettingsAdvancedFragment extends Fragment {
         );
         mBlurOnLockScreenCheckBox.setChecked(!Prefs.getSharedPreferences(getContext())
                 .getBoolean(Prefs.PREF_DISABLE_BLUR_WHEN_LOCKED, false));
-        return rootView;
     }
 
     @Override

--- a/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/SettingsChooseSourceFragment.java
@@ -101,7 +101,6 @@ public class SettingsChooseSourceFragment extends Fragment {
 
     private Handler mHandler = new Handler();
 
-    private ViewGroup mRootView;
     private ViewGroup mSourceContainerView;
     private ObservableHorizontalScrollView mSourceScrollerView;
     private Scrollbar mScrollbar;
@@ -206,10 +205,17 @@ public class SettingsChooseSourceFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              Bundle savedInstanceState) {
-        mRootView = (ViewGroup) inflater.inflate(
+        return inflater.inflate(
                 R.layout.settings_choose_source_fragment, container, false);
-        mScrollbar = mRootView.findViewById(R.id.source_scrollbar);
-        mSourceScrollerView = mRootView.findViewById(R.id.source_scroller);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull final View view, @Nullable Bundle savedInstanceState) {
+        // Ensure we have the latest insets
+        view.requestFitSystemWindows();
+
+        mScrollbar = view.findViewById(R.id.source_scrollbar);
+        mSourceScrollerView = view.findViewById(R.id.source_scroller);
         mSourceScrollerView.setCallbacks(new ObservableHorizontalScrollView.Callbacks() {
             @Override
             public void onScrollChanged(int scrollX) {
@@ -224,12 +230,12 @@ public class SettingsChooseSourceFragment extends Fragment {
                 }
             }
         });
-        mSourceContainerView = mRootView.findViewById(R.id.source_container);
+        mSourceContainerView = view.findViewById(R.id.source_container);
 
         redrawSources();
 
-        mRootView.setVisibility(View.INVISIBLE);
-        mRootView.getViewTreeObserver().addOnGlobalLayoutListener(
+        view.setVisibility(View.INVISIBLE);
+        view.getViewTreeObserver().addOnGlobalLayoutListener(
                 new ViewTreeObserver.OnGlobalLayoutListener() {
                     int mPass = 0;
 
@@ -243,26 +249,25 @@ public class SettingsChooseSourceFragment extends Fragment {
                             // Second pass
                             mSourceScrollerView.setScrollX(mItemWidth * mSelectedSourceIndex);
                             showScrollbar();
-                            mRootView.setVisibility(View.VISIBLE);
+                            view.setVisibility(View.VISIBLE);
                             ++mPass;
                         } else {
                             // Last pass, remove the listener
-                            mRootView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                            view.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                         }
                     }
                 });
 
-        mRootView.setAlpha(0);
-        mRootView.animate().alpha(1f).setDuration(500);
-        return mRootView;
+        view.setAlpha(0);
+        view.animate().alpha(1f).setDuration(500);
     }
 
     private void updatePadding() {
-        int rootViewWidth = mRootView.getWidth();
+        int rootViewWidth = getView().getWidth();
         if (rootViewWidth == 0) {
             return;
         }
-        int topPadding = Math.max(0, (mRootView.getHeight() - mItemEstimatedHeight) / 2);
+        int topPadding = Math.max(0, (getView().getHeight() - mItemEstimatedHeight) / 2);
         int numItems = mSources.size();
         int sidePadding;
         int minSidePadding = getResources().getDimensionPixelSize(

--- a/main/src/main/java/com/google/android/apps/muzei/util/SmartInsetLinearLayout.java
+++ b/main/src/main/java/com/google/android/apps/muzei/util/SmartInsetLinearLayout.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.util;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
+
+/**
+ * A vertical {@link LinearLayout} that transforms fitsSystemWindows insets into vertical padding
+ * for only the top and bottom child.
+ */
+public class SmartInsetLinearLayout extends LinearLayout {
+    public SmartInsetLinearLayout(final Context context) {
+        super(context);
+        init();
+    }
+
+    public SmartInsetLinearLayout(final Context context, @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public SmartInsetLinearLayout(final Context context, @Nullable final AttributeSet attrs,
+            final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        setOrientation(LinearLayout.VERTICAL);
+    }
+
+    @Override
+    protected boolean fitSystemWindows(final Rect insets) {
+        Rect horizontalInsets = new Rect(insets.left, 0, insets.right, 0);
+        super.fitSystemWindows(horizontalInsets);
+        int childCount = getChildCount();
+        if (childCount > 0) {
+            View firstChild = getChildAt(0);
+            firstChild.setPadding(firstChild.getPaddingLeft(),
+                    insets.top,
+                    firstChild.getPaddingRight(),
+                    (childCount == 1 ? insets.bottom : 0));
+            if (childCount > 1) {
+                View lastChild = getChildAt(childCount - 1);
+                lastChild.setPadding(lastChild.getPaddingLeft(),
+                        lastChild.getPaddingTop(),
+                        lastChild.getPaddingRight(),
+                        insets.bottom);
+            }
+
+        }
+        return true;
+    }
+}

--- a/main/src/main/res/drawable/ic_main_choose_source.xml
+++ b/main/src/main/res/drawable/ic_main_choose_source.xml
@@ -14,14 +14,13 @@
   limitations under the License.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item
-        android:id="@+id/action_notification_settings"
-        android:title="@string/notification_settings"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/action_get_more_sources"
-        android:title="@string/get_more_sources"
-        app:showAsAction="never" />
-</menu>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFF"
+        android:pathData="M4,4h7L11,2L4,2c-1.1,0 -2,0.9 -2,2v7h2L4,4zM10,13l-4,5h12l-3,-4 -2.03,2.71L10,13zM17,8.5c0,-0.83 -0.67,-1.5 -1.5,-1.5S14,7.67 14,8.5s0.67,1.5 1.5,1.5S17,9.33 17,8.5zM20,2h-7v2h7v7h2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,20h-7v2h7c1.1,0 2,-0.9 2,-2v-7h-2v7zM4,13L2,13v7c0,1.1 0.9,2 2,2h7v-2L4,20v-7z"/>
+</vector>

--- a/main/src/main/res/drawable/ic_main_effects.xml
+++ b/main/src/main/res/drawable/ic_main_effects.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2014 Google Inc.
+  Copyright 2017 Google Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
   limitations under the License.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:id="@+id/action_get_more_sources"
-        android:title="@string/get_more_sources"
-        android:menuCategory="secondary"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/action_about"
-        android:title="@string/about_title"
-        android:menuCategory="secondary"
-        app:showAsAction="never" />
-</menu>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFF"
+        android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z"/>
+</vector>

--- a/main/src/main/res/layout-sw600dp/settings_advanced_fragment.xml
+++ b/main/src/main/res/layout-sw600dp/settings_advanced_fragment.xml
@@ -15,9 +15,9 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <include layout="@layout/settings_advanced_fragment_include_content"
         android:layout_width="500dp"

--- a/main/src/main/res/layout-v21/main_fragment.xml
+++ b/main/src/main/res/layout-v21/main_fragment.xml
@@ -1,0 +1,46 @@
+<!--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/action_bar_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"/>
+    </FrameLayout>
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+    <android.support.design.widget.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/black"
+        android:fitsSystemWindows="true"
+        app:menu="@menu/main"/>
+</LinearLayout>

--- a/main/src/main/res/layout/art_detail_fragment.xml
+++ b/main/src/main/res/layout/art_detail_fragment.xml
@@ -82,12 +82,6 @@
 
     </FrameLayout>
 
-    <View android:id="@+id/statusbar_scrim"
-          android:layout_width="match_parent"
-          android:layout_height="160dp"
-          android:layout_gravity="top"
-          android:background="@android:color/transparent" />
-
     <LinearLayout android:id="@+id/chrome_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -99,7 +93,7 @@
         <FrameLayout android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:paddingTop="192dp"> <!-- extend gradient -->
+            android:paddingTop="64dp"> <!-- extend gradient -->
 
             <LinearLayout android:id="@+id/metadata"
                 android:clickable="true"

--- a/main/src/main/res/layout/main_fragment.xml
+++ b/main/src/main/res/layout/main_fragment.xml
@@ -1,0 +1,47 @@
+<!--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<com.google.android.apps.muzei.util.SmartInsetLinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <FrameLayout
+        android:id="@+id/action_bar_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"/>
+    </FrameLayout>
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+    <android.support.design.widget.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/black"
+        android:fitsSystemWindows="true"
+        app:menu="@menu/main"/>
+</com.google.android.apps.muzei.util.SmartInsetLinearLayout>

--- a/main/src/main/res/layout/settings_advanced_fragment.xml
+++ b/main/src/main/res/layout/settings_advanced_fragment.xml
@@ -18,7 +18,8 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="32dp">
+    android:paddingStart="32dp"
+    android:paddingEnd="32dp">
 
     <include layout="@layout/settings_advanced_fragment_include_content"
         android:layout_width="match_parent"

--- a/main/src/main/res/layout/settings_advanced_fragment.xml
+++ b/main/src/main/res/layout/settings_advanced_fragment.xml
@@ -15,11 +15,11 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingStart="32dp"
-    android:paddingEnd="32dp">
+    android:layout_marginStart="32dp"
+    android:layout_marginEnd="32dp"
+    android:fitsSystemWindows="true">
 
     <include layout="@layout/settings_advanced_fragment_include_content"
         android:layout_width="match_parent"

--- a/main/src/main/res/layout/settings_choose_source_fragment.xml
+++ b/main/src/main/res/layout/settings_choose_source_fragment.xml
@@ -16,9 +16,9 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.apps.muzei.util.ObservableHorizontalScrollView
         android:id="@+id/source_scroller"

--- a/main/src/main/res/menu/main.xml
+++ b/main/src/main/res/menu/main.xml
@@ -14,14 +14,17 @@
   limitations under the License.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/action_notification_settings"
-        android:title="@string/notification_settings"
-        app:showAsAction="never" />
+        android:id="@+id/main_art_details"
+        android:title="@string/app_name"
+        android:icon="@drawable/ic_stat_muzei"/>
     <item
-        android:id="@+id/action_get_more_sources"
-        android:title="@string/get_more_sources"
-        app:showAsAction="never" />
+        android:id="@+id/main_choose_source"
+        android:title="@string/section_choose_source"
+        android:icon="@drawable/ic_main_choose_source"/>
+    <item
+        android:id="@+id/main_effects"
+        android:title="@string/section_effects"
+        android:icon="@drawable/ic_main_effects"/>
 </menu>

--- a/main/src/main/res/menu/muzei_overflow.xml
+++ b/main/src/main/res/menu/muzei_overflow.xml
@@ -16,8 +16,9 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:id="@+id/action_settings"
-        android:title="@string/action_settings"
-        android:orderInCategory="10000"
+    <item
+        android:id="@+id/action_about"
+        android:title="@string/about_title"
+        android:menuCategory="secondary"
         app:showAsAction="never" />
 </menu>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
 
     <string name="section_choose_source">Sources</string>
     <string name="section_advanced">Advanced</string>
+    <string name="section_effects">Effects</string>
 
     <string name="action_next_artwork">Next artwork</string>
     <string name="action_next_artwork_condensed">Next</string>


### PR DESCRIPTION
Expose all of the main functionality of Muzei on a global bottom nav:
- Muzei (the main art details screen that Muzei already starts on)
- Sources (the Sources settings screen)
- Effects (the 'Advanced' settings screen)

Tapping on the art details screen not only hides the art details information, but also the bottom nav, retaining the full screen view of the artwork. Tapping on the Muzei bottom navigation button when it is already selected also triggers the full screen view.

This replaces the existing method of reaching the Sources and Effects screens via the 'Customize' option in the overflow menu on the art details screen. The SettingsActivity that contains the Sources/Effects screen is still in use as the configuration activity for setting the wallpaper, but is otherwise not accessible.

The About Muzei option is no longer in the global overflow menu for the SettingsActivity, but is now in the overflow menu for the art details screen (i.e., where Customize used to be).