### PR TITLE
Only zoom images if needed to fill the screen size

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
@@ -388,9 +388,8 @@ class MuzeiBlurRenderer(private val context: Context,
                 return
             }
 
-            // Ensure the bitmap is wider than the screen relatively by applying zoom
-            // if necessary. Vary width but keep height the same.
-            val zoom = Math.max(1f, 1.15f * screenToBitmapAspectRatio)
+            // Ensure the bitmap is as wide as the screen by applying zoom if necessary
+            val zoom = Math.max(1f, screenToBitmapAspectRatio)
 
             // Total scale factors in both zoom and scale due to aspect ratio.
             val scaledBitmapToScreenAspectRatio = zoom / screenToBitmapAspectRatio


### PR DESCRIPTION
Instead of using an effective minimum width of 1.15 of the screen's width, only zoom images if absolutely required to avoid black bars on the sides of the screen. This then allows artwork of the exact size of the screen to fit without scrolling.

Fixes #409