### PR TITLE
Update to Support Library 28.0.0-alpha3, add support for display cutouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@
 
 buildscript {
     ext {
-        compileSdkVersion = 27
+        compileSdkVersion = 28
         targetSdkVersion = 25
 
         kotlinVersion = "1.2.41"
         coroutinesVersion = "0.22.5"
         ktxVersion = "0.3"
-        supportLibraryVersion = "27.1.1"
+        supportLibraryVersion = "28.0.0-alpha3"
         constraintLayoutVersion = "1.1.0"
         lifecycleVersion = "1.1.1"
         roomVersion = "1.1.1-rc1"

--- a/main/src/main/java/com/google/android/apps/muzei/MainFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/MainFragment.kt
@@ -161,7 +161,14 @@ class MainFragment : Fragment(), FragmentManager.OnBackStackChangedListener, Cho
                             0,
                             insets.systemWindowInsetRight,
                             insets.systemWindowInsetBottom))
-            insets.consumeSystemWindowInsets()
+            insets.consumeSystemWindowInsets().run {
+                // Workaround for https://issuetracker.google.com/issues/109830520
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    consumeDisplayCutout()
+                } else {
+                    this
+                }
+            }
         }
 
         // Listen for visibility changes to know when to hide our views

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
   limitations under the License.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Muzei activity -->
 
@@ -93,6 +93,7 @@
     <style name="Theme.Muzei.Wallpaper" parent="Theme.Muzei">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowShowWallpaper">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
     </style>
 
     <style name="Widget.Muzei.PopupMenu" parent="Widget.AppCompat.PopupMenu">


### PR DESCRIPTION
When Muzei goes to full screen, allow the wallpaper to display around any display cutouts.

Fixes #522