### PR TITLE
Allow users to browse artwork and set the wallpaper

### DIFF
--- a/android-client-common/src/main/res/values/colors.xml
+++ b/android-client-common/src/main/res/values/colors.xml
@@ -16,6 +16,7 @@
 
 <resources>
     <color name="theme_primary">#3c6caf</color>
+    <color name="theme_primary_dark">#00427f</color>
     <color name="theme_accent">#fff</color>
 
     <color name="notification">@color/theme_primary</color>

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ buildscript {
         classpath "io.fabric.tools:gradle:1.25.4"
         classpath "com.google.firebase:firebase-plugins:1.1.5"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
     }
 }
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'io.fabric'
+apply plugin: 'androidx.navigation.safeargs'
 
 project.archivesBaseName = "muzei"
 

--- a/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
@@ -47,7 +47,9 @@ import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.toast
+import androidx.navigation.fragment.findNavController
 import com.google.android.apps.muzei.api.provider.MuzeiArtProvider
+import com.google.android.apps.muzei.api.provider.ProviderContract
 import com.google.android.apps.muzei.notifications.NotificationSettingsDialogFragment
 import com.google.android.apps.muzei.room.MuzeiDatabase
 import com.google.android.apps.muzei.room.select
@@ -236,6 +238,7 @@ class ChooseProviderFragment : Fragment() {
         private val providerArtwork: ImageView = itemView.findViewById(R.id.provider_artwork)
         private val providerDescription: TextView = itemView.findViewById(R.id.provider_description)
         private val providerSettings: Button = itemView.findViewById(R.id.provider_settings)
+        private val providerBrowse: Button = itemView.findViewById(R.id.provider_browse)
 
         private var isSelected = false
 
@@ -303,6 +306,13 @@ class ChooseProviderFragment : Fragment() {
 
             setSelected(providerInfo)
             providerSettings.setOnClickListener { launchProviderSettings(this) }
+            providerBrowse.setOnClickListener {
+                findNavController().navigate(
+                        ChooseProviderFragmentDirections.browse(
+                                ProviderContract.Artwork.getContentUri(
+                                        requireContext(),
+                                        componentName)))
+            }
         }
 
         override fun onSuccess() {
@@ -333,6 +343,7 @@ class ChooseProviderFragment : Fragment() {
             isSelected = selected
             providerSelected.isInvisible = !selected
             providerSettings.isVisible = selected && settingsActivity != null
+            providerBrowse.isVisible = selected
         }
     }
 

--- a/main/src/main/java/com/google/android/apps/muzei/browse/BrowseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/browse/BrowseProviderFragment.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.browse
+
+import android.arch.lifecycle.ViewModelProvider
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
+import android.support.v7.graphics.drawable.DrawerArrowDrawable
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.Toolbar
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.core.widget.toast
+import androidx.navigation.fragment.findNavController
+import com.google.android.apps.muzei.room.Artwork
+import com.google.android.apps.muzei.room.MuzeiDatabase
+import com.google.android.apps.muzei.util.observe
+import com.squareup.picasso.Picasso
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.withContext
+import net.nurik.roman.muzei.R
+
+class BrowseProviderFragment: Fragment() {
+    private val viewModelProvider by lazy {
+        ViewModelProvider(this, ViewModelProvider.AndroidViewModelFactory
+                .getInstance(requireActivity().application))
+    }
+    private val viewModel by lazy {
+        viewModelProvider[BrowseProviderViewModel::class.java]
+    }
+    private val adapter = Adapter()
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.browse_provider_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        // Ensure we have the latest insets
+        @Suppress("DEPRECATION")
+        view.requestFitSystemWindows()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = ContextCompat.getColor(
+                    requireContext(), R.color.theme_primary_dark)
+        }
+
+        val args = BrowseProviderFragmentArgs.fromBundle(arguments)
+        val pm = requireContext().packageManager
+        val providerInfo = pm.resolveContentProvider(args.contentUri.authority, 0)
+                ?: run {
+                    findNavController().popBackStack()
+                    return
+                }
+
+        view.findViewById<Toolbar>(R.id.browse_toolbar).apply {
+            navigationIcon = DrawerArrowDrawable(requireContext()).apply {
+                progress = 1f
+            }
+            setNavigationOnClickListener {
+                findNavController().popBackStack()
+            }
+            title = providerInfo.loadLabel(pm)
+        }
+        view.findViewById<RecyclerView>(R.id.browse_list).adapter = adapter
+
+        viewModel.setContentUri(args.contentUri)
+        viewModel.artLiveData.observe(this) {
+            adapter.submitList(it)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = Color.TRANSPARENT
+        }
+    }
+
+    class ArtViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
+        private val imageView = itemView.findViewById<ImageView>(R.id.browse_image)
+
+        fun bind(artwork: Artwork) {
+            imageView.contentDescription = artwork.title
+            Picasso.get()
+                    .load(artwork.imageUri)
+                    .centerCrop()
+                    .fit()
+                    .into(imageView)
+            itemView.setOnClickListener {
+                val context = it.context
+                launch(UI) {
+                    withContext(CommonPool) {
+                        MuzeiDatabase.getInstance(context).artworkDao()
+                                .insert(artwork)
+                    }
+                    context.toast(if (artwork.title.isNullOrBlank()) {
+                        context.getString(R.string.browse_set_wallpaper)
+                    } else {
+                        context.getString(R.string.browse_set_wallpaper_with_title,
+                                artwork.title)
+                    })
+                }
+
+            }
+        }
+    }
+
+    inner class Adapter: ListAdapter<Artwork, ArtViewHolder>(
+            object: DiffUtil.ItemCallback<Artwork>() {
+                override fun areItemsTheSame(artwork1: Artwork, artwork2: Artwork) =
+                        artwork1.imageUri == artwork2.imageUri
+
+                override fun areContentsTheSame(artwork1: Artwork, artwork2: Artwork) =
+                        artwork1 == artwork2
+            }
+    ) {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+                ArtViewHolder(layoutInflater.inflate(
+                        R.layout.browse_provider_item, parent, false))
+
+        override fun onBindViewHolder(holder: ArtViewHolder, position: Int) {
+            holder.bind(getItem(position))
+        }
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/browse/BrowseProviderViewModel.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/browse/BrowseProviderViewModel.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.browse
+
+import android.app.Application
+import android.arch.lifecycle.AndroidViewModel
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Transformations
+import android.content.ComponentName
+import android.content.ContentUris
+import android.content.Context
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import com.google.android.apps.muzei.room.Artwork
+import com.google.android.apps.muzei.util.ContentProviderClientCompat
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.newSingleThreadContext
+
+class ProviderArtworkLiveData(
+        val context: Context,
+        val contentUri: Uri
+): MutableLiveData<List<Artwork>>() {
+    private val componentName: ComponentName = context.packageManager
+            .resolveContentProvider(contentUri.authority, 0).run {
+        ComponentName(applicationInfo.packageName, name)
+    }
+    private val singleThreadContext by lazy {
+        newSingleThreadContext("ProviderArtworkLiveData")
+    }
+    private val contentObserver = object : ContentObserver(Handler()) {
+        override fun onChange(selfChange: Boolean, uri: Uri?) {
+            refreshArt()
+        }
+    }
+    private lateinit var contentProviderClient: ContentProviderClientCompat
+    private var open: Boolean = false
+
+    override fun onActive() {
+        contentProviderClient = ContentProviderClientCompat.getClient(context, contentUri)
+                ?: return
+        context.contentResolver.registerContentObserver(
+                contentUri,
+                true,
+                contentObserver)
+        open = true
+        refreshArt()
+    }
+
+    override fun onInactive() {
+        if (open) {
+            context.contentResolver.unregisterContentObserver(contentObserver)
+            contentProviderClient.close()
+            open = false
+        }
+    }
+
+    private fun refreshArt() {
+        launch(singleThreadContext) {
+            val list = mutableListOf<Artwork>()
+            contentProviderClient.query(contentUri)?.use { data ->
+                while(data.moveToNext()) {
+                    val providerArtwork =
+                            com.google.android.apps.muzei.api.provider.Artwork.fromCursor(data)
+                    list.add(Artwork(ContentUris.withAppendedId(contentUri,
+                            providerArtwork.id)).apply {
+                        title = providerArtwork.title
+                        byline = providerArtwork.byline
+                        attribution = providerArtwork.attribution
+                        providerComponentName = componentName
+                    })
+                }
+            }
+            postValue(list)
+        }
+    }
+}
+
+class BrowseProviderViewModel(
+        application: Application
+): AndroidViewModel(application) {
+    private val contentUriLiveData = MutableLiveData<Uri>()
+
+    fun setContentUri(contentUri: Uri) {
+        contentUriLiveData.value = contentUri
+    }
+
+    val artLiveData: LiveData<List<Artwork>> = Transformations
+            .switchMap(contentUriLiveData) { contentUri ->
+                ProviderArtworkLiveData(application, contentUri)
+            }
+}

--- a/main/src/main/res/layout/browse_provider_fragment.xml
+++ b/main/src/main/res/layout/browse_provider_fragment.xml
@@ -1,0 +1,46 @@
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/browse_coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    app:statusBarBackground="@color/theme_primary_dark"
+    android:background="@color/browse_provider_background">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/browse_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            app:layout_scrollFlags="scroll|enterAlways"/>
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/browse_list"
+        android:layout_width="match_parent"
+        android:drawSelectorOnTop="true"
+        android:layout_height="match_parent"
+        app:layoutManager="android.support.v7.widget.GridLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:spanCount="@integer/browse_provider_span_count"/>
+</android.support.design.widget.CoordinatorLayout>

--- a/main/src/main/res/layout/browse_provider_item.xml
+++ b/main/src/main/res/layout/browse_provider_item.xml
@@ -1,0 +1,37 @@
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?selectableItemBackground">
+
+    <ImageView
+        android:id="@+id/browse_image"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription"/>
+</android.support.constraint.ConstraintLayout>

--- a/main/src/main/res/layout/choose_provider_fragment.xml
+++ b/main/src/main/res/layout/choose_provider_fragment.xml
@@ -50,7 +50,7 @@
             android:paddingStart="@dimen/provider_padding"
             app:layoutManager="android.support.v7.widget.StaggeredGridLayoutManager"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            app:spanCount="@integer/provider_span_count"/>
+            app:spanCount="@integer/choose_provider_span_count"/>
     </android.support.design.widget.CoordinatorLayout>
 
     <fragment

--- a/main/src/main/res/navigation/main_navigation.xml
+++ b/main/src/main/res/navigation/main_navigation.xml
@@ -29,7 +29,23 @@
         android:id="@+id/main_choose_provider"
         android:name="com.google.android.apps.muzei.ChooseProviderFragment"
         android:label="@string/section_choose_source"
-        tools:layout="@layout/choose_provider_fragment"/>
+        tools:layout="@layout/choose_provider_fragment">
+        <action
+            android:id="@+id/browse"
+            app:destination="@+id/browse_provider"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+    </fragment>
+    <fragment
+        android:id="@+id/browse_provider"
+        android:name="com.google.android.apps.muzei.browse.BrowseProviderFragment"
+        tools:layout="@layout/browse_provider_fragment">
+        <argument
+            android:name="contentUri"
+            app:type="android.net.Uri"/>
+    </fragment>
     <fragment
         android:id="@+id/main_effects"
         android:name="com.google.android.apps.muzei.settings.EffectsFragment"

--- a/main/src/main/res/values-w600dp/integers.xml
+++ b/main/src/main/res/values-w600dp/integers.xml
@@ -15,5 +15,6 @@
   -->
 
 <resources>
-    <integer name="provider_span_count">2</integer>
+    <integer name="choose_provider_span_count">2</integer>
+    <integer name="browse_provider_span_count">3</integer>
 </resources>

--- a/main/src/main/res/values-w960dp/integers.xml
+++ b/main/src/main/res/values-w960dp/integers.xml
@@ -15,5 +15,6 @@
   -->
 
 <resources>
-    <integer name="provider_span_count">3</integer>
+    <integer name="choose_provider_span_count">3</integer>
+    <integer name="browse_provider_span_count">4</integer>
 </resources>

--- a/main/src/main/res/values/colors.xml
+++ b/main/src/main/res/values/colors.xml
@@ -17,4 +17,5 @@
 <resources>
     <color name="shortcut_background">#F5F5F5</color>
     <color name="art_detail_loading_background">#c000</color>
+    <color name="browse_provider_background">#111</color>
 </resources>

--- a/main/src/main/res/values/integers.xml
+++ b/main/src/main/res/values/integers.xml
@@ -18,5 +18,6 @@
     <integer name="tutorial_icon_emanate_duration">2000</integer>
     <integer name="tutorial_icon_emanate_wave2_delay">400</integer>
 
-    <integer name="provider_span_count">1</integer>
+    <integer name="choose_provider_span_count">1</integer>
+    <integer name="browse_provider_span_count">2</integer>
 </resources>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -90,6 +90,9 @@
     <string name="reset_advanced_settings_defaults">Reset sliders</string>
     <string name="play_store_not_found">Unable to open Play Store.</string>
 
+    <string name="browse_set_wallpaper">Set the current wallpaper</string>
+    <string name="browse_set_wallpaper_with_title">Set the current wallpaper to \"%s\"</string>
+
     <string name="missing_resources_title">Invalid Muzei installation</string>
     <string name="missing_resources_message">Muzei is in an invalid state. Please uninstall Muzei and install it from the Google Play Store to repair your installation.</string>
     <string name="missing_resources_open">Open Play Store</string>


### PR DESCRIPTION
Add a new 'Browse' action for each selected provider that allows users to browse through all of the artwork a provider has loaded and set the current wallpaper to any wallpaper.

Fixes #486 