### PR TITLE
Add settings to customize gestures

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
@@ -38,6 +38,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.navigation.fragment.findNavController
 import com.google.android.apps.muzei.api.MuzeiArtSource
 import com.google.android.apps.muzei.api.MuzeiContract
 import com.google.android.apps.muzei.notifications.NewWallpaperNotificationReceiver
@@ -249,6 +250,11 @@ class ArtDetailFragment : Fragment(), (Boolean) -> Unit {
             }
 
             return@setOnMenuItemClickListener when (menuItem.itemId) {
+                R.id.action_gestures -> {
+                    FirebaseAnalytics.getInstance(context).logEvent("gestures_open", null)
+                    findNavController().navigate(ArtDetailFragmentDirections.gestures())
+                    true
+                }
                 R.id.action_about -> {
                     FirebaseAnalytics.getInstance(context).logEvent("about_open", null)
                     startActivity(Intent(context, AboutActivity::class.java))

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
@@ -301,9 +301,9 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
             if (WallpaperManager.COMMAND_TAP == action && validDoubleTap) {
                 val prefs = Prefs.getSharedPreferences(this@MuzeiWallpaperService)
                 val doubleTapValue = prefs.getString(Prefs.PREF_DOUBLE_TAP,
-                        Prefs.PREF_DOUBLE_TAP_TEMP)
+                        Prefs.PREF_TAP_ACTION_TEMP)
                 when (doubleTapValue) {
-                    Prefs.PREF_DOUBLE_TAP_TEMP -> {
+                    Prefs.PREF_TAP_ACTION_TEMP -> {
                         // Temporarily toggle focused/blurred
                         queueEvent {
                             renderer.setIsBlurred(!renderer.isBlurred, false)
@@ -311,10 +311,10 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
                             delayedBlur()
                         }
                     }
-                    Prefs.PREF_DOUBLE_TAP_NEXT -> {
+                    Prefs.PREF_TAP_ACTION_NEXT -> {
                         SourceManager.nextArtwork(this@MuzeiWallpaperService)
                     }
-                    Prefs.PREF_DOUBLE_TAP_VIEW_DETAILS -> {
+                    Prefs.PREF_TAP_ACTION_VIEW_DETAILS -> {
                         launch {
                             val artwork = MuzeiDatabase
                                     .getInstance(this@MuzeiWallpaperService)

--- a/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.settings
+
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
+import android.support.v7.graphics.drawable.DrawerArrowDrawable
+import android.support.v7.widget.Toolbar
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.RadioGroup
+import androidx.core.content.edit
+import androidx.navigation.fragment.findNavController
+import net.nurik.roman.muzei.R
+
+class GesturesFragment: Fragment() {
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.gestures_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        // Ensure we have the latest insets
+        @Suppress("DEPRECATION")
+        view.requestFitSystemWindows()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = ContextCompat.getColor(
+                    requireContext(), R.color.theme_primary_dark)
+        }
+
+        view.findViewById<Toolbar>(R.id.gestures_toolbar).apply {
+            navigationIcon = DrawerArrowDrawable(requireContext()).apply {
+                progress = 1f
+            }
+            setNavigationOnClickListener {
+                findNavController().popBackStack()
+            }
+        }
+
+        val prefs = Prefs.getSharedPreferences(requireContext())
+        val doubleTap = view.findViewById<RadioGroup>(R.id.gestures_double_tap_action)
+        val doubleTapValue = prefs.getString(Prefs.PREF_DOUBLE_TAP,
+                Prefs.PREF_DOUBLE_TAP_TEMP)
+        doubleTap.check(when (doubleTapValue) {
+            Prefs.PREF_DOUBLE_TAP_TEMP -> R.id.gestures_double_tap_temporary_disable
+            Prefs.PREF_DOUBLE_TAP_NEXT -> R.id.gestures_double_tap_next
+            Prefs.PREF_DOUBLE_TAP_VIEW_DETAILS -> R.id.gestures_double_tap_view_details
+            else -> R.id.gestures_double_tap_none
+        })
+        doubleTap.setOnCheckedChangeListener { _, index ->
+            val newValue = when(index) {
+                R.id.gestures_double_tap_temporary_disable -> Prefs.PREF_DOUBLE_TAP_TEMP
+                R.id.gestures_double_tap_next -> Prefs.PREF_DOUBLE_TAP_NEXT
+                R.id.gestures_double_tap_view_details -> Prefs.PREF_DOUBLE_TAP_VIEW_DETAILS
+                else -> Prefs.PREF_DOUBLE_TAP_NONE
+            }
+            prefs.edit {
+                putString(Prefs.PREF_DOUBLE_TAP, newValue)
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = Color.TRANSPARENT
+        }
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
@@ -62,19 +62,19 @@ class GesturesFragment: Fragment() {
         val prefs = Prefs.getSharedPreferences(requireContext())
         val doubleTap = view.findViewById<RadioGroup>(R.id.gestures_double_tap_action)
         val doubleTapValue = prefs.getString(Prefs.PREF_DOUBLE_TAP,
-                Prefs.PREF_DOUBLE_TAP_TEMP)
+                Prefs.PREF_TAP_ACTION_TEMP)
         doubleTap.check(when (doubleTapValue) {
-            Prefs.PREF_DOUBLE_TAP_TEMP -> R.id.gestures_double_tap_temporary_disable
-            Prefs.PREF_DOUBLE_TAP_NEXT -> R.id.gestures_double_tap_next
-            Prefs.PREF_DOUBLE_TAP_VIEW_DETAILS -> R.id.gestures_double_tap_view_details
+            Prefs.PREF_TAP_ACTION_TEMP -> R.id.gestures_double_tap_temporary_disable
+            Prefs.PREF_TAP_ACTION_NEXT -> R.id.gestures_double_tap_next
+            Prefs.PREF_TAP_ACTION_VIEW_DETAILS -> R.id.gestures_double_tap_view_details
             else -> R.id.gestures_double_tap_none
         })
         doubleTap.setOnCheckedChangeListener { _, index ->
             val newValue = when(index) {
-                R.id.gestures_double_tap_temporary_disable -> Prefs.PREF_DOUBLE_TAP_TEMP
-                R.id.gestures_double_tap_next -> Prefs.PREF_DOUBLE_TAP_NEXT
-                R.id.gestures_double_tap_view_details -> Prefs.PREF_DOUBLE_TAP_VIEW_DETAILS
-                else -> Prefs.PREF_DOUBLE_TAP_NONE
+                R.id.gestures_double_tap_temporary_disable -> Prefs.PREF_TAP_ACTION_TEMP
+                R.id.gestures_double_tap_next -> Prefs.PREF_TAP_ACTION_NEXT
+                R.id.gestures_double_tap_view_details -> Prefs.PREF_TAP_ACTION_VIEW_DETAILS
+                else -> Prefs.PREF_TAP_ACTION_NONE
             }
             prefs.edit {
                 putString(Prefs.PREF_DOUBLE_TAP, newValue)

--- a/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/GesturesFragment.kt
@@ -80,6 +80,27 @@ class GesturesFragment: Fragment() {
                 putString(Prefs.PREF_DOUBLE_TAP, newValue)
             }
         }
+
+        val threeFingerTap = view.findViewById<RadioGroup>(R.id.gestures_three_finger_tap_action)
+        val threeFingerTapValue = prefs.getString(Prefs.PREF_THREE_FINGER_TAP,
+                Prefs.PREF_TAP_ACTION_NONE)
+        threeFingerTap.check(when (threeFingerTapValue) {
+            Prefs.PREF_TAP_ACTION_TEMP -> R.id.gestures_three_finger_tap_temporary_disable
+            Prefs.PREF_TAP_ACTION_NEXT -> R.id.gestures_three_finger_tap_next
+            Prefs.PREF_TAP_ACTION_VIEW_DETAILS -> R.id.gestures_three_finger_tap_view_details
+            else -> R.id.gestures_three_finger_tap_none
+        })
+        threeFingerTap.setOnCheckedChangeListener { _, index ->
+            val newValue = when(index) {
+                R.id.gestures_three_finger_tap_temporary_disable -> Prefs.PREF_TAP_ACTION_TEMP
+                R.id.gestures_three_finger_tap_next -> Prefs.PREF_TAP_ACTION_NEXT
+                R.id.gestures_three_finger_tap_view_details -> Prefs.PREF_TAP_ACTION_VIEW_DETAILS
+                else -> Prefs.PREF_TAP_ACTION_NONE
+            }
+            prefs.edit {
+                putString(Prefs.PREF_THREE_FINGER_TAP, newValue)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
@@ -27,6 +27,11 @@ import androidx.core.content.edit
  * Preference constants/helpers.
  */
 object Prefs {
+    const val PREF_DOUBLE_TAP = "double_tap"
+    const val PREF_DOUBLE_TAP_TEMP = "temp"
+    const val PREF_DOUBLE_TAP_NEXT = "next"
+    const val PREF_DOUBLE_TAP_VIEW_DETAILS = "view_details"
+    const val PREF_DOUBLE_TAP_NONE = "none"
     const val PREF_GREY_AMOUNT = "grey_amount"
     const val PREF_DIM_AMOUNT = "dim_amount"
     const val PREF_BLUR_AMOUNT = "blur_amount"

--- a/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
@@ -28,6 +28,7 @@ import androidx.core.content.edit
  */
 object Prefs {
     const val PREF_DOUBLE_TAP = "double_tap"
+    const val PREF_THREE_FINGER_TAP = "three_finger_tap"
     const val PREF_TAP_ACTION_TEMP = "temp"
     const val PREF_TAP_ACTION_NEXT = "next"
     const val PREF_TAP_ACTION_VIEW_DETAILS = "view_details"

--- a/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/settings/Prefs.kt
@@ -28,10 +28,10 @@ import androidx.core.content.edit
  */
 object Prefs {
     const val PREF_DOUBLE_TAP = "double_tap"
-    const val PREF_DOUBLE_TAP_TEMP = "temp"
-    const val PREF_DOUBLE_TAP_NEXT = "next"
-    const val PREF_DOUBLE_TAP_VIEW_DETAILS = "view_details"
-    const val PREF_DOUBLE_TAP_NONE = "none"
+    const val PREF_TAP_ACTION_TEMP = "temp"
+    const val PREF_TAP_ACTION_NEXT = "next"
+    const val PREF_TAP_ACTION_VIEW_DETAILS = "view_details"
+    const val PREF_TAP_ACTION_NONE = "none"
     const val PREF_GREY_AMOUNT = "grey_amount"
     const val PREF_DIM_AMOUNT = "dim_amount"
     const val PREF_BLUR_AMOUNT = "blur_amount"

--- a/main/src/main/res/layout/gestures_fragment.xml
+++ b/main/src/main/res/layout/gestures_fragment.xml
@@ -1,0 +1,120 @@
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<android.support.design.widget.CoordinatorLayout
+    android:id="@+id/browse_coordinator"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/browse_provider_background"
+    android:fitsSystemWindows="true"
+    app:statusBarBackground="@color/theme_primary_dark">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/gestures_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            app:layout_scrollFlags="scroll|enterAlways|snap"
+            app:title="@string/gestures_title"/>
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:fillViewport="false"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/gestures_double_tap_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/gestures_double_tap_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                app:layout_constraintBottom_toTopOf="@+id/gestures_double_tap_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed"
+                app:layout_constraintWidth_max="500dp"/>
+
+            <TextView
+                android:id="@+id/gestures_double_tap_description"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/gestures_double_tap_description"
+                app:layout_constraintBottom_toTopOf="@+id/gestures_double_tap_action"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gestures_double_tap_title"
+                app:layout_constraintWidth_max="500dp"/>
+
+            <RadioGroup
+                android:id="@+id/gestures_double_tap_action"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gestures_double_tap_description"
+                app:layout_constraintWidth_max="500dp">
+
+                <RadioButton
+                    android:id="@+id/gestures_double_tap_temporary_disable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_double_tap_temporary_disable"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_double_tap_next"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_double_tap_next"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_double_tap_view_details"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/gestures_double_tap_view_details"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_double_tap_none"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_double_tap_none"/>
+
+            </RadioGroup>
+        </android.support.constraint.ConstraintLayout>
+    </android.support.v4.widget.NestedScrollView>
+</android.support.design.widget.CoordinatorLayout>

--- a/main/src/main/res/layout/gestures_fragment.xml
+++ b/main/src/main/res/layout/gestures_fragment.xml
@@ -90,7 +90,7 @@
                     android:layout_height="wrap_content"
                     android:paddingBottom="8dp"
                     android:paddingTop="8dp"
-                    android:text="@string/gestures_double_tap_temporary_disable"/>
+                    android:text="@string/gestures_tap_action_temporary_disable"/>
 
                 <RadioButton
                     android:id="@+id/gestures_double_tap_next"
@@ -98,13 +98,13 @@
                     android:layout_height="wrap_content"
                     android:paddingBottom="8dp"
                     android:paddingTop="8dp"
-                    android:text="@string/gestures_double_tap_next"/>
+                    android:text="@string/gestures_tap_action_next"/>
 
                 <RadioButton
                     android:id="@+id/gestures_double_tap_view_details"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/gestures_double_tap_view_details"/>
+                    android:text="@string/gestures_tap_action_view_details"/>
 
                 <RadioButton
                     android:id="@+id/gestures_double_tap_none"
@@ -112,7 +112,7 @@
                     android:layout_height="wrap_content"
                     android:paddingBottom="8dp"
                     android:paddingTop="8dp"
-                    android:text="@string/gestures_double_tap_none"/>
+                    android:text="@string/gestures_tap_action_none"/>
 
             </RadioGroup>
         </android.support.constraint.ConstraintLayout>

--- a/main/src/main/res/layout/gestures_fragment.xml
+++ b/main/src/main/res/layout/gestures_fragment.xml
@@ -78,7 +78,7 @@
                 android:id="@+id/gestures_double_tap_action"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/gestures_three_finger_tap_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/gestures_double_tap_description"
@@ -108,6 +108,74 @@
 
                 <RadioButton
                     android:id="@+id/gestures_double_tap_none"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_tap_action_none"/>
+
+            </RadioGroup>
+
+            <TextView
+                android:id="@+id/gestures_three_finger_tap_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/gestures_three_finger_tap_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                app:layout_constraintBottom_toTopOf="@+id/gestures_three_finger_tap_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gestures_double_tap_action"
+                app:layout_constraintWidth_max="500dp"/>
+
+            <TextView
+                android:id="@+id/gestures_three_finger_tap_description"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/gestures_three_finger_tap_description"
+                app:layout_constraintBottom_toTopOf="@+id/gestures_three_finger_tap_action"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gestures_three_finger_tap_title"
+                app:layout_constraintWidth_max="500dp"/>
+
+            <RadioGroup
+                android:id="@+id/gestures_three_finger_tap_action"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gestures_three_finger_tap_description"
+                app:layout_constraintWidth_max="500dp">
+
+                <RadioButton
+                    android:id="@+id/gestures_three_finger_tap_temporary_disable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_tap_action_temporary_disable"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_three_finger_tap_next"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="8dp"
+                    android:text="@string/gestures_tap_action_next"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_three_finger_tap_view_details"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/gestures_tap_action_view_details"/>
+
+                <RadioButton
+                    android:id="@+id/gestures_three_finger_tap_none"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingBottom="8dp"

--- a/main/src/main/res/menu/muzei_overflow.xml
+++ b/main/src/main/res/menu/muzei_overflow.xml
@@ -18,6 +18,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_gestures"
+        android:title="@string/actions_gestures"
+        android:menuCategory="secondary"
+        app:showAsAction="never"/>
+    <item
         android:id="@+id/action_about"
         android:title="@string/about_title"
         android:menuCategory="secondary"

--- a/main/src/main/res/navigation/main_navigation.xml
+++ b/main/src/main/res/navigation/main_navigation.xml
@@ -24,7 +24,20 @@
         android:id="@+id/main_art_details"
         android:name="com.google.android.apps.muzei.ArtDetailFragment"
         android:label="ArtDetailFragment"
-        tools:layout="@layout/art_detail_fragment"/>
+        tools:layout="@layout/art_detail_fragment">
+        <action
+            android:id="@+id/gestures"
+            app:destination="@+id/gestures_fragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+    </fragment>
+    <fragment
+        android:id="@+id/gestures_fragment"
+        android:name="com.google.android.apps.muzei.settings.GesturesFragment"
+        android:label="@string/gestures_title"
+        tools:layout="@layout/gestures_fragment"/>
     <fragment
         android:id="@+id/main_choose_provider"
         android:name="com.google.android.apps.muzei.ChooseProviderFragment"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -106,10 +106,10 @@
     <string name="gestures_double_tap_title">Double Tap</string>
     <string name="gestures_double_tap_description">Double tap the blurred wallpaper on your home
         screen to trigger the action of your choice.</string>
-    <string name="gestures_double_tap_temporary_disable">Temporarily disable effects</string>
-    <string name="gestures_double_tap_next">Next Artwork</string>
-    <string name="gestures_double_tap_view_details">View Artwork Details</string>
-    <string name="gestures_double_tap_none">None</string>
+    <string name="gestures_tap_action_temporary_disable">Temporarily disable effects</string>
+    <string name="gestures_tap_action_next">Next Artwork</string>
+    <string name="gestures_tap_action_view_details">View Artwork Details</string>
+    <string name="gestures_tap_action_none">None</string>
 
     <string name="about_title">About Muzei</string>
     <string name="about_body"><![CDATA[

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -101,6 +101,16 @@
     <string name="missing_resources_open">Open Play Store</string>
     <string name="missing_resources_quit">Close Muzei</string>
 
+    <string name="actions_gestures">Customize Gestures</string>
+    <string name="gestures_title">Gestures</string>
+    <string name="gestures_double_tap_title">Double Tap</string>
+    <string name="gestures_double_tap_description">Double tap the blurred wallpaper on your home
+        screen to trigger the action of your choice.</string>
+    <string name="gestures_double_tap_temporary_disable">Temporarily disable effects</string>
+    <string name="gestures_double_tap_next">Next Artwork</string>
+    <string name="gestures_double_tap_view_details">View Artwork Details</string>
+    <string name="gestures_double_tap_none">None</string>
+
     <string name="about_title">About Muzei</string>
     <string name="about_body"><![CDATA[
         Made by Roman Nurik and Ian Lake, with major contributions from

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="gestures_double_tap_title">Double Tap</string>
     <string name="gestures_double_tap_description">Double tap the blurred wallpaper on your home
         screen to trigger the action of your choice.</string>
+    <string name="gestures_three_finger_tap_title">Three Finger Tap</string>
+    <string name="gestures_three_finger_tap_description">Tap the blurred wallpaper on your home
+        screen with three fingers to trigger the action of your choice.</string>
     <string name="gestures_tap_action_temporary_disable">Temporarily disable effects</string>
     <string name="gestures_tap_action_next">Next Artwork</string>
     <string name="gestures_tap_action_view_details">View Artwork Details</string>


### PR DESCRIPTION
Instead of only having a fixed action (temporarily disabling effects) on one gesture (double tap), expand the set of gestures and actions that Muzei supports out of the box to include:
- Both double tap and three finger tap gestures
- Temporarily disable effects, next artwork, view artwork details, or none as available actions