### PR TITLE
Treat recent artwork ids as a set

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/RecentArtworkIdsConverter.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/RecentArtworkIdsConverter.java
@@ -30,7 +30,11 @@ public class RecentArtworkIdsConverter {
         TextUtils.SimpleStringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
         splitter.setString(idsString);
         while (splitter.hasNext()) {
-            ids.add(Long.parseLong(splitter.next()));
+            long id = Long.parseLong(splitter.next());
+            // Remove the id if it exists in the list already
+            ids.remove(id);
+            // Then add it to the end of the list
+            ids.add(id);
         }
         return ids;
     }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -362,6 +362,9 @@ public abstract class MuzeiArtProvider extends ContentProvider {
                         // Update the list of recent artwork ids
                         ArrayDeque<Long> recentArtworkIds = RecentArtworkIdsConverter.fromString(
                                 prefs.getString(PREF_RECENT_ARTWORK_IDS, ""));
+                        // Remove the loadedId if it exists in the list already
+                        recentArtworkIds.remove(loadedId);
+                        // Then add the loadedId to the end of the list
                         recentArtworkIds.addLast(loadedId);
                         int maxSize = Math.min(Math.max(data.getCount(), 1), MAX_RECENT_ARTWORK);
                         while (recentArtworkIds.size() > maxSize) {


### PR DESCRIPTION
Ensure there's no duplicates in the recent artwork id list by removing any existing ids when adding a new id. This avoids unnecessary cache misses due to removeAutoCachedFile being called too early.

Fixes #556 