### PR TITLE
Use the _ID to determine the last loaded artwork

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -285,7 +285,7 @@ public abstract class MuzeiArtProvider extends ContentProvider {
     @Nullable
     protected final Artwork getLastAddedArtwork() {
         try (Cursor data = query(contentUri, null, null, null,
-                ProviderContract.Artwork.DATE_ADDED + " DESC")) {
+                BaseColumns._ID + " DESC")) {
             return data.moveToFirst() ? Artwork.fromCursor(data) : null;
         }
     }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderContract.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderContract.java
@@ -184,7 +184,7 @@ public class ProviderContract {
             try (Cursor data = context.getContentResolver().query(
                     getContentUri(context, provider),
                     null, null, null,
-                    DATE_ADDED + " DESC")) {
+                    BaseColumns._ID + " DESC")) {
                 return data != null && data.moveToFirst()
                         ? com.google.android.apps.muzei.api.provider.Artwork.fromCursor(data)
                         : null;


### PR DESCRIPTION
Since the _ID auto-increments, it is a unique indicator or the last added artwork.

Fixes #555