### PR TITLE
Only do a full update() from addArtwork() if something changed

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 
-apiName = 3.0.0-alpha01
+apiName = 3.0.0-alpha02
 apiCode = 300
 
 name = 3.0.0
 # Version number + unique ID for the build
-codeWear = 300007
+codeWear = 300009
 # Main app must be unique from the Wear version
-code = 300006
+code = 300008
 
 # Latest beta number for this version. Only applies to beta builds.
-betaNumber = Alpha 3
+betaNumber = Alpha 4


### PR DESCRIPTION
Avoid doing a full update (and the subsequent notifyChange()) if nothing actually changed. This removes cases where there's just a single image and it is unconditionally changed every time onLoadRequested() is called, causing an infinite loading loop.

When developers specifically call update(), we always call notifyChange() in case they are sorting by DATE_MODIFIED and want an updated list.

Fixes #559 