### PR TITLE
Inform MuzeiArtProviders about invalid artwork

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
@@ -31,6 +31,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
+import com.google.android.apps.muzei.api.internal.ProtocolConstants
 import com.google.android.apps.muzei.api.internal.ProtocolConstants.KEY_MAX_LOADED_ARTWORK_ID
 import com.google.android.apps.muzei.api.internal.ProtocolConstants.KEY_RECENT_ARTWORK_IDS
 import com.google.android.apps.muzei.api.internal.ProtocolConstants.METHOD_GET_LOAD_INFO
@@ -230,6 +231,12 @@ class ArtworkLoadWorker : Worker() {
                         byline = providerArtwork.byline
                         attribution = providerArtwork.attribution
                     }
+                } else {
+                    if (BuildConfig.DEBUG) {
+                        Log.w(TAG, "Artwork $artworkUri is not a valid image")
+                    }
+                    // Tell the client that the artwork is invalid
+                    client.call(ProtocolConstants.METHOD_MARK_ARTWORK_INVALID, artworkUri.toString())
                 }
             }
         } catch (e: IOException) {

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
@@ -265,7 +265,15 @@ class ProviderChangedWorker : Worker() {
         val artworkUri = ContentUris.withAppendedId(contentUri, providerArtwork.id)
         try {
             client.openInputStream(artworkUri)?.use { inputStream ->
-                return inputStream.isValidImage()
+                if (inputStream.isValidImage()) {
+                    return true
+                } else {
+                    if (BuildConfig.DEBUG) {
+                        Log.w(TAG, "Artwork $artworkUri is not a valid image")
+                    }
+                    // Tell the client that the artwork is invalid
+                    client.call(ProtocolConstants.METHOD_MARK_ARTWORK_INVALID, artworkUri.toString())
+                }
             }
         } catch (e: IOException) {
             Log.w(TAG, "Unable to preload artwork $artworkUri", e)

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/ProtocolConstants.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/ProtocolConstants.java
@@ -38,6 +38,7 @@ public class ProtocolConstants {
     // MuzeiArtProvider
     private static final String PREFIX = "com.google.android.apps.muzei.api.";
     public static final String METHOD_REQUEST_LOAD = PREFIX + "REQUEST_LOAD";
+    public static final String METHOD_MARK_ARTWORK_INVALID = PREFIX + "MARK_ARTWORK_INVALID";
     public static final String METHOD_MARK_ARTWORK_LOADED = PREFIX + "MARK_ARTWORK_LOADED";
     public static final String METHOD_GET_LOAD_INFO = PREFIX + "GET_LOAD_INFO";
     public static final String KEY_MAX_LOADED_ARTWORK_ID = PREFIX + "MAX_LOADED_ARTWORK_ID";


### PR DESCRIPTION
Instead of silently ignoring invalid artwork (artwork that cannot be loaded by Muzei due to image format issues), we send a signal to the MuzeiArtProvider so that it can delete its invalid artwork.

Fixes #564