### PR TITLE
Fix insert of an artwork with an existing token

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -650,7 +650,8 @@ public abstract class MuzeiArtProvider extends ContentProvider {
                                         ProviderContract.Artwork.WEB_URI)) &&
                                 TextUtils.equals(metadata, values.getAsString(
                                         ProviderContract.Artwork.METADATA));
-                        long id = existingData.getLong(0);
+                        long id = existingData.getLong(existingData.getColumnIndex(
+                                BaseColumns._ID));
                         Uri updateUri = ContentUris.withAppendedId(contentUri, id);
                         if (noChange) {
                             // Just update the DATE_MODIFIED and don't send a notifyChange()


### PR DESCRIPTION
Ensure that we use the correct ID when doing an update to an existing artwork in response to an insert.

Fixes #566 