### PR TITLE
Allow Tasker to select any installed provider

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -183,7 +183,7 @@
         <!-- Activity and receiver which allows Tasker to trigger the 'Next Artwork' action -->
         <activity
             android:name="com.google.android.apps.muzei.tasker.TaskerSettingActivity"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@style/Theme.Muzei.Dialog">
             <intent-filter>
                 <action android:name="com.twofortyfouram.locale.intent.action.EDIT_SETTING"/>
             </intent-filter>

--- a/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerAction.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerAction.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.tasker
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+
+private const val ACTION_NEXT_ARTWORK = "next_artwork"
+private const val ACTION_SELECT_PROVIDER = "select_provider"
+private const val EXTRA_ACTION = "com.google.android.apps.muzei.TASKER_ACTION"
+private const val EXTRA_PROVIDER_AUTHORITY = "com.google.android.apps.muzei.PROVIDER_NAME"
+
+internal sealed class TaskerAction {
+
+    companion object {
+        fun fromBundle(bundle: Bundle?) = when(bundle?.getString(EXTRA_ACTION)) {
+            ACTION_SELECT_PROVIDER -> bundle.getString(EXTRA_PROVIDER_AUTHORITY)?.let { authority ->
+                SelectProviderAction(authority)
+            } ?: InvalidAction
+            else -> NextArtworkAction
+        }
+    }
+
+    open fun toBundle(): Bundle = Bundle()
+}
+
+internal object NextArtworkAction : TaskerAction() {
+    override fun toBundle() = bundleOf(
+            EXTRA_ACTION to ACTION_NEXT_ARTWORK)
+}
+
+internal class SelectProviderAction(val authority: String) : TaskerAction() {
+    override fun toBundle() = bundleOf(
+            EXTRA_ACTION to ACTION_SELECT_PROVIDER,
+            EXTRA_PROVIDER_AUTHORITY to authority)
+}
+
+internal object InvalidAction : TaskerAction()

--- a/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerActionReceiver.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerActionReceiver.kt
@@ -20,15 +20,33 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.google.android.apps.muzei.sources.SourceManager
+import com.google.android.apps.muzei.sync.ProviderManager
 import com.twofortyfouram.locale.api.Intent.ACTION_FIRE_SETTING
+import com.twofortyfouram.locale.api.Intent.EXTRA_BUNDLE
+import kotlinx.coroutines.experimental.launch
 
 /**
- * Tasker FIRE_SETTING receiver that fires source actions
+ * Tasker FIRE_SETTING receiver that fires a [TaskerAction]
  */
 class TaskerActionReceiver : BroadcastReceiver() {
+
     override fun onReceive(context: Context, intent: Intent?) {
-        if (intent?.action == ACTION_FIRE_SETTING) {
-            SourceManager.nextArtwork(context)
+        if (intent?.action != ACTION_FIRE_SETTING) {
+            return
+        }
+        val selectedAction = TaskerAction.fromBundle(intent.getBundleExtra(EXTRA_BUNDLE))
+        when (selectedAction) {
+            is SelectProviderAction -> {
+                val authority = selectedAction.authority
+                if (context.packageManager.resolveContentProvider(authority, 0) != null) {
+                    val result = goAsync()
+                    launch {
+                        ProviderManager.select(context, authority)
+                        result.finish()
+                    }
+                }
+            }
+            is NextArtworkAction -> SourceManager.nextArtwork(context)
         }
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerSettingActivity.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerSettingActivity.kt
@@ -16,22 +16,89 @@
 
 package com.google.android.apps.muzei.tasker
 
-import android.app.Activity
+import android.arch.lifecycle.ViewModelProvider
+import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
+import android.support.v7.app.AppCompatActivity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import com.google.android.apps.muzei.util.observeNonNull
+import com.twofortyfouram.locale.api.Intent.EXTRA_BUNDLE
 import com.twofortyfouram.locale.api.Intent.EXTRA_STRING_BLURB
 import net.nurik.roman.muzei.R
 
 /**
- * A minimal EDIT_SETTINGS activity for a Tasker Plugin
+ * The EDIT_SETTINGS activity for a Tasker Plugin allowing users to select whether they
+ * want the Tasker action to move to the next artwork or select a particular provider
  */
-class TaskerSettingActivity : Activity() {
+class TaskerSettingActivity : AppCompatActivity() {
+
+    private val viewModelProvider by lazy {
+        ViewModelProvider(this, ViewModelProvider.AndroidViewModelFactory
+                .getInstance(application))
+    }
+    private val viewModel by lazy {
+        viewModelProvider[TaskerSettingViewModel::class.java]
+    }
+
+    private val adapter by lazy {
+        ActionAdapter(this)
+    }
+
+    private val dialog: AlertDialog by lazy {
+        AlertDialog.Builder(this, R.style.Theme_Muzei_Dialog)
+                .setTitle(R.string.tasker_setting_dialog_title)
+                .setSingleChoiceItems(adapter, -1) { _: DialogInterface, which: Int ->
+                    val action = adapter.getItem(which) ?: return@setSingleChoiceItems
+                    val intent = Intent().apply {
+                        putExtra(EXTRA_STRING_BLURB, action.text)
+                        putExtra(EXTRA_BUNDLE, action.action.toBundle())
+                    }
+                    setResult(RESULT_OK, intent)
+                    finish()
+                }
+                .setOnCancelListener {
+                    setResult(RESULT_CANCELED, null)
+                    finish()
+                }
+                .create()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val intent = Intent().apply {
-            putExtra(EXTRA_STRING_BLURB, getString(R.string.action_next_artwork))
+        viewModel.actions.observeNonNull(this) { actions ->
+            adapter.clear()
+            adapter.addAll(actions)
+            if (!dialog.isShowing) {
+                dialog.show()
+            }
         }
-        setResult(Activity.RESULT_OK, intent)
-        finish()
+    }
+
+    override fun onDestroy() {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+        super.onDestroy()
+    }
+
+    private class ActionAdapter(
+            context: Context
+    ) : ArrayAdapter<Action>(context, R.layout.tasker_action_item, 0) {
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val view = super.getView(position, convertView, parent) as TextView
+            getItem(position)?.let { action ->
+                view.setCompoundDrawablesRelative(
+                        action.icon, null, null, null)
+                view.text = action.text
+            }
+            return view
+        }
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerSettingViewModel.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerSettingViewModel.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.tasker
+
+import android.app.Application
+import android.arch.lifecycle.AndroidViewModel
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import android.content.pm.ProviderInfo
+import android.graphics.drawable.Drawable
+import android.support.v4.content.ContextCompat
+import com.google.android.apps.muzei.room.InstalledProvidersLiveData
+import net.nurik.roman.muzei.BuildConfig
+import net.nurik.roman.muzei.R
+
+internal data class Action(
+        val icon: Drawable,
+        val text: String,
+        val action: TaskerAction,
+        val packageName: String? = null)
+
+internal class TaskerSettingViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val imageSize = application.resources.getDimensionPixelSize(
+            R.dimen.tasker_action_icon_size)
+
+    private val comparator = Comparator<Action> { a1, a2 ->
+        // The Next Artwork action should always be first
+        if (a1.action is NextArtworkAction) {
+            return@Comparator -1
+        } else if (a2.action is NextArtworkAction) {
+            return@Comparator 1
+        }
+        // The SourceArtProvider should always the last provider listed
+        if (a1.action is SelectProviderAction &&
+                a1.action.authority == BuildConfig.SOURCES_AUTHORITY) {
+            return@Comparator 1
+        } else if (a2.action is SelectProviderAction &&
+                a2.action.authority == BuildConfig.SOURCES_AUTHORITY) {
+            return@Comparator -1
+        }
+        // Then put providers from Muzei on top
+        val pn1 = a1.packageName
+        val pn2 = a2.packageName
+        if (pn1 != pn2) {
+            if (application.packageName == pn1) {
+                return@Comparator -1
+            } else if (application.packageName == pn2) {
+                return@Comparator 1
+            }
+        }
+        // Finally, sort actions by their text
+        a1.text.compareTo(a2.text)
+    }
+
+    val actions : LiveData<List<Action>?> = object : MutableLiveData<List<Action>?>() {
+        val nextArtworkAction = Action(
+                ContextCompat.getDrawable(application, R.drawable.ic_next_artwork)!!.apply {
+                    setBounds(0, 0, imageSize, imageSize)
+                },
+                application.getString(R.string.action_next_artwork),
+                NextArtworkAction)
+
+        val installedProvidersLiveData = InstalledProvidersLiveData(application)
+        val installedProvidersObserver = Observer<List<ProviderInfo>> { providers ->
+            val pm = application.packageManager
+            val actionsList = mutableListOf(nextArtworkAction)
+            providers?.forEach { providerInfo ->
+                actionsList.add(Action(
+                        providerInfo.loadIcon(pm).apply {
+                            setBounds(0, 0, imageSize, imageSize)
+                        },
+                        application.getString(R.string.tasker_action_select_provider,
+                                providerInfo.loadLabel(pm)),
+                        SelectProviderAction(providerInfo.authority)))
+            }
+            value = actionsList.sortedWith(comparator)
+        }
+
+        override fun onActive() {
+            installedProvidersLiveData.observeForever(installedProvidersObserver)
+        }
+
+        override fun onInactive() {
+            installedProvidersLiveData.removeObserver(installedProvidersObserver)
+        }
+    }
+}

--- a/main/src/main/res/layout/tasker_action_item.xml
+++ b/main/src/main/res/layout/tasker_action_item.xml
@@ -1,0 +1,30 @@
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:drawablePadding="16dp"
+    android:ellipsize="end"
+    android:gravity="center_vertical"
+    android:maxLines="3"
+    android:paddingBottom="8dp"
+    android:paddingEnd="24dp"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+    android:textColor="#b3ffffff"/>

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -37,6 +37,8 @@
     <dimen name="settings_text_size_large">20sp</dimen>
     <dimen name="settings_text_size_normal">16sp</dimen>
 
+    <dimen name="tasker_action_icon_size">48dp</dimen>
+
     <dimen name="widget_small_height_breakpoint">110dp</dimen>
     <dimen name="widget_min_size">48dp</dimen>
     <dimen name="widget_min_height">110dp</dimen>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -107,6 +107,9 @@
     <string name="missing_resources_open">Open Play Store</string>
     <string name="missing_resources_quit">Close Muzei</string>
 
+    <string name="tasker_setting_dialog_title">Select action</string>
+    <string name="tasker_action_select_provider">Select %s</string>
+
     <string name="actions_gestures">Customize Gestures</string>
     <string name="gestures_title">Gestures</string>
     <string name="gestures_double_tap_title">Double Tap</string>


### PR DESCRIPTION
Expand the current Tasker plugin to allow users to not only select the 'Next Artwork' action, but also actions to select any available MuzeiArtProvider.

This does not run any setup activity under the assumption that users have already set up any provider they select and the rarity of setup activities in general.

Fixes #417