### PR TITLE
Rethrow non-IOExceptions as SecurityExceptions

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -961,8 +961,14 @@ public abstract class MuzeiArtProvider extends ContentProvider {
                 || ContentResolver.SCHEME_ANDROID_RESOURCE.equals(scheme)) {
             try {
                 in = context.getContentResolver().openInputStream(persistentUri);
+            } catch (IOException e) {
+                // Rethrow IOExceptions to retry later
+                throw e;
             } catch (SecurityException e) {
-                throw new FileNotFoundException("No access to " + persistentUri + ": " + e.toString());
+                throw new SecurityException("No access to " + persistentUri + ": " + e.toString());
+            } catch (Exception e) {
+                throw new SecurityException("Unknown error accessing " + persistentUri + ": " +
+                        e.toString());
             }
         } else if (ContentResolver.SCHEME_FILE.equals(scheme)) {
             List<String> segments = persistentUri.getPathSegments();


### PR DESCRIPTION
When a content:// URI triggers a non-IOException error, we should treat that as a permanent error. For MuzeiArtProvider's openFile, that means rethrowing them as a SecurityException.

Fixes #575 