### PR TITLE
Prevent SQL Injection into MuzeiArtProvider.query

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -604,6 +604,7 @@ public abstract class MuzeiArtProvider extends ContentProvider {
         final SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
         qb.setTables(TABLE_NAME);
         qb.setProjectionMap(allArtworkColumnProjectionMap);
+        qb.setStrict(true);
         final SQLiteDatabase db = databaseHelper.getReadableDatabase();
         if (!uri.equals(contentUri)) {
             // Appends "_ID = <id>" to the where clause, so that it selects the single artwork


### PR DESCRIPTION
Use setStrict(true) to prevent possible SQL injection issues when MuzeiArtProviders don't use the permission or during automated Google Play Store testing (which don't take the permission into account).

Fixes #577 