### PR TITLE
Ensure MuzeiArtProviders cannot crash Muzei

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
@@ -213,14 +213,12 @@ class ArtworkLoadWorker(
                     }
                 }
             }
-            return Result.FAILURE
         } catch (e: RemoteException) {
-            Log.i(TAG, "Provider $authority crashed while retrieving artwork", e)
-            return Result.FAILURE
+            Log.i(TAG, "Provider $authority crashed while retrieving artwork: ${e.message}")
         }
+        return Result.RETRY
     }
 
-    @Throws(RemoteException::class)
     private suspend fun checkForValidArtwork(
             client: ContentProviderClientCompat,
             contentUri: Uri,
@@ -245,7 +243,10 @@ class ArtworkLoadWorker(
                 }
             }
         } catch (e: IOException) {
-            Log.w(TAG, "Unable to preload artwork $artworkUri", e)
+            Log.w(TAG, "Unable to preload artwork $artworkUri: ${e.message}")
+        } catch (e: RemoteException) {
+            Log.w(TAG, "Provider ${contentUri.authority} crashed preloading artwork " +
+                    "$artworkUri: ${e.message}")
         }
 
         return null

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
@@ -240,7 +240,7 @@ class ProviderChangedWorker(
                 }
             }
         } catch (e: RemoteException) {
-            Log.i(TAG, "Provider ${provider.authority} crashed while retrieving artwork", e)
+            Log.i(TAG, "Provider ${provider.authority} crashed while retrieving artwork: ${e.message}")
         }
         return Result.RETRY
     }
@@ -259,7 +259,6 @@ class ProviderChangedWorker(
         return false
     }
 
-    @Throws(RemoteException::class)
     private suspend fun isValidArtwork(
             client: ContentProviderClientCompat,
             contentUri: Uri,
@@ -280,7 +279,10 @@ class ProviderChangedWorker(
                 }
             }
         } catch (e: IOException) {
-            Log.w(TAG, "Unable to preload artwork $artworkUri", e)
+            Log.w(TAG, "Unable to preload artwork $artworkUri: ${e.message}")
+        } catch (e: RemoteException) {
+            Log.w(TAG, "Provider ${contentUri.authority} crashed preloading artwork " +
+                    "$artworkUri: ${e.message}")
         }
 
         return false


### PR DESCRIPTION
Parcel.writeException details a set of RuntimeExceptions that are sent over to the calling app. If a MuzeiArtProvider threw any of these RuntimeExceptions, they'd crash Muzei - we want to avoid that by catching all of these exceptions and rethrowing them as RemoteException, which Muzei uses as the signal that the remote MuzeiArtProvider crashed.

Special handling was added around checking for valid artwork to ensure the now RemoteExceptions don't take down the entire Worker, but instead are captured locally and mark the artwork as invalid.

Fixes #581 