### PR TITLE
Adds a way to intercept openFile calls even if the image is cached

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -877,6 +877,9 @@ public abstract class MuzeiArtProvider extends ContentProvider {
             }
             artwork = Artwork.fromCursor(data);
         }
+        if (!isArtworkValid(artwork)) {
+            throw new SecurityException("Artwork was marked as invalid by the MuzeiArtProvider");
+        }
         if (!artwork.getData().exists() && mode.equals("r")) {
             // Download the image from the persistent URI for read-only operations
             // rather than throw a FileNotFoundException
@@ -924,6 +927,22 @@ public abstract class MuzeiArtProvider extends ContentProvider {
                 artwork.getData().delete();
             }
         }
+    }
+
+    /**
+     * Called every time an image is loaded (even if there is a cached
+     * image available). This gives you an opportunity to circumvent the
+     * typical loading process and remove previously cached artwork on
+     * demand. The default implementation always returns <code>true</code>.
+     * <p>
+     * In most cases, you should proactively delete Artwork that you know
+     * is not valid rather than wait for this callback since at this point
+     * the user is specifically waiting for the image to appear.
+     * @param artwork The Artwork to confirm
+     * @return Whether the Artwork is valid and should be loaded
+     */
+    public boolean isArtworkValid(@NonNull Artwork artwork) {
+        return true;
     }
 
     /**


### PR DESCRIPTION
When the image is already cached, `openFile(Artwork)` is never called. While that's totally fine for loading the image, in some cases, the MuzeiArtProvider might not know if an image is still valid until right when it is loaded (i.e., the source image could have been deleted).

Add a isArtworkValid method that is called by openFile(Uri, String) to give MuzeiArtProviders the hook needed to invalidate images that are already cached.