### PR TITLE
Call onInvalidArtwork when isArtworkValid returns false

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -878,6 +878,7 @@ public abstract class MuzeiArtProvider extends ContentProvider {
             artwork = Artwork.fromCursor(data);
         }
         if (!isArtworkValid(artwork)) {
+            onInvalidArtwork(artwork);
             throw new SecurityException("Artwork was marked as invalid by the MuzeiArtProvider");
         }
         if (!artwork.getData().exists() && mode.equals("r")) {
@@ -938,6 +939,10 @@ public abstract class MuzeiArtProvider extends ContentProvider {
      * In most cases, you should proactively delete Artwork that you know
      * is not valid rather than wait for this callback since at this point
      * the user is specifically waiting for the image to appear.
+     * <p>
+     * The MuzeiArtProvider will call {@link #onInvalidArtwork(Artwork)} for you
+     * if you return <code>false</code>false - there is no need to call this
+     * manually from within this method.
      * @param artwork The Artwork to confirm
      * @return Whether the Artwork is valid and should be loaded
      */


### PR DESCRIPTION
Rather than relying on ArtworkLoadWorker to call onInvalidArtwork, call it directly in cases where isArtworkValid returns false. This ensures that the Artwork is cleaned up when the file is opened for different purposes (i.e., from the BrowseFragment).