### PR TITLE
Move static methods in ProviderContract.Artwork to ProviderClient

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ArtworkLoadWorker.kt
@@ -111,7 +111,7 @@ class ArtworkLoadWorker(
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Artwork Load for $authority")
         }
-        val contentUri = ProviderContract.Artwork.getContentUri(authority)
+        val contentUri = ProviderContract.getContentUri(authority)
         try {
             ContentProviderClientCompat.getClient(applicationContext, contentUri)?.use { client ->
                 val result = client.call(METHOD_GET_LOAD_INFO)

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderChangedWorker.kt
@@ -139,7 +139,7 @@ class ProviderChangedWorker(
                                 providerLiveData.removeObserver(this)
                                 // Make sure we're still not actively listening
                                 if (!providerManager.hasActiveObservers()) {
-                                    val contentUri = ProviderContract.Artwork.getContentUri(
+                                    val contentUri = ProviderContract.getContentUri(
                                             provider.authority)
                                     scheduleObserver(contentUri)
                                 }
@@ -191,7 +191,7 @@ class ProviderChangedWorker(
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Provider Change ($tag) for ${provider.authority}")
         }
-        val contentUri = ProviderContract.Artwork.getContentUri(provider.authority)
+        val contentUri = ProviderContract.getContentUri(provider.authority)
         try {
             ContentProviderClientCompat.getClient(applicationContext, contentUri)?.use { client ->
                 val result = client.call(METHOD_GET_LOAD_INFO)
@@ -261,7 +261,7 @@ class ProviderChangedWorker(
         MuzeiDatabase.getInstance(applicationContext).artworkDao()
                 .getCurrentArtworkForProvider(provider.authority)?.let { artwork ->
                     client.query(artwork.imageUri)?.use { cursor ->
-                        val contentUri = ProviderContract.Artwork.getContentUri(provider.authority)
+                        val contentUri = ProviderContract.getContentUri(provider.authority)
                         return cursor.moveToNext() && isValidArtwork(client, contentUri, cursor)
                     }
                 }

--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderManager.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderManager.kt
@@ -229,7 +229,7 @@ class ProviderManager private constructor(private val context: Context)
                     Log.d(TAG, "Starting artwork load")
                 }
                 // Listen for MuzeiArtProvider changes
-                val contentUri = ProviderContract.Artwork.getContentUri(currentSource.authority)
+                val contentUri = ProviderContract.getContentUri(currentSource.authority)
                 context.contentResolver.registerContentObserver(
                         contentUri, true, contentObserver)
                 ProviderChangedWorker.enqueueSelected()

--- a/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashExampleWorker.kt
+++ b/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashExampleWorker.kt
@@ -61,6 +61,8 @@ class UnsplashExampleWorker(
             return Result.FAILURE
         }
 
+        val providerClient = ProviderContract.getProviderClient(
+                applicationContext, UNSPLASH_AUTHORITY)
         val attributionString = applicationContext.getString(R.string.attribution)
         photos.map { photo ->
             Artwork().apply {
@@ -73,9 +75,7 @@ class UnsplashExampleWorker(
                 metadata = photo.user.links.webUri.toString()
             }
         }.forEach { artwork ->
-            ProviderContract.Artwork.addArtwork(applicationContext,
-                    UNSPLASH_AUTHORITY,
-                    artwork)
+            providerClient.addArtwork(artwork)
         }
         return Result.SUCCESS
     }

--- a/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
@@ -338,7 +338,7 @@ class ChooseProviderFragment : Fragment() {
                         FirebaseAnalytics.Param.ITEM_NAME to title))
                 findNavController().navigate(
                         ChooseProviderFragmentDirections.browse(
-                                ProviderContract.Artwork.getContentUri(authority)))
+                                ProviderContract.getContentUri(authority)))
             }
         }
 

--- a/main/src/main/java/com/google/android/apps/muzei/sources/SourceSubscriberService.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/sources/SourceSubscriberService.kt
@@ -88,8 +88,8 @@ class SourceSubscriberService : IntentService("SourceSubscriberService") {
                 webUri = currentArtwork.viewIntent?.toUri(Intent.URI_INTENT_SCHEME)?.toUri()
             }
 
-            val artworkUri = ProviderContract.Artwork.setArtwork(this,
-                    SOURCES_AUTHORITY, newArtwork)
+            val artworkUri = ProviderContract.getProviderClient(this,
+                    SOURCES_AUTHORITY).setArtwork(newArtwork)
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Set artwork to: $artworkUri")
             }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/Artwork.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/Artwork.java
@@ -49,9 +49,8 @@ import static com.google.android.apps.muzei.api.provider.ProviderContract.Artwor
  * <p>
  * Artwork can then be added to a {@link MuzeiArtProvider} by calling
  * {@link MuzeiArtProvider#addArtwork(Artwork) addArtwork(Artwork)} directly
- * from within a MuzeiArtProvider or by calling
- * {@link ProviderContract.Artwork#addArtwork(Context, Class, Artwork)}
- * from anywhere in your application.
+ * from within a MuzeiArtProvider or by creating a {@link ProviderClient} and calling
+ * {@link ProviderClient#addArtwork(Artwork)} from anywhere in your application.
  * </p>
  * <p>
  * The static {@link Artwork#fromCursor(Cursor)} method allows you to convert

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.apps.muzei.api.provider;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * Interface for interacting with a {@link MuzeiArtProvider}. Methods of this interface can
+ * be used directly within a MuzeiArtProvider or you can get an instance via
+ * {@link ProviderContract#getProviderClient(Context, Class)} or
+ * {@link ProviderContract#getProviderClient(Context, String)}.
+ */
+public interface ProviderClient {
+    /**
+     * Retrieve the content URI for the {@link MuzeiArtProvider}, allowing you to build
+     * custom queries, inserts, updates, and deletes using a {@link ContentResolver}.
+     *
+     * @return The content URI for the {@link MuzeiArtProvider}
+     */
+    @NonNull
+    Uri getContentUri();
+
+    /**
+     * Retrieve the last added artwork from the {@link MuzeiArtProvider}.
+     *
+     * @return The last added Artwork, or null if no artwork has been added
+     */
+    @Nullable
+    Artwork getLastAddedArtwork();
+
+    /**
+     * Add a new piece of artwork to the {@link MuzeiArtProvider}.
+     *
+     * @param artwork The artwork to add
+     * @return The URI of the newly added artwork or null if the insert failed
+     */
+    @Nullable
+    Uri addArtwork(@NonNull Artwork artwork);
+
+    /**
+     * Set the {@link MuzeiArtProvider} to only show the given artwork, deleting any other
+     * artwork previously added. Only in the cases where the artwork is successfully inserted
+     * will the other artwork be removed.
+     *
+     * @param artwork The artwork to set
+     * @return The URI of the newly set artwork or null if the insert failed
+     */
+    @Nullable
+    Uri setArtwork(@NonNull Artwork artwork);
+}

--- a/source-featured-art/src/main/java/com/google/android/apps/muzei/featuredart/FeaturedArtWorker.kt
+++ b/source-featured-art/src/main/java/com/google/android/apps/muzei/featuredart/FeaturedArtWorker.kt
@@ -128,9 +128,8 @@ class FeaturedArtWorker(
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Adding new artwork: $imageUri")
             }
-            ProviderContract.Artwork.addArtwork(applicationContext,
-                    FEATURED_ART_AUTHORITY,
-                    artwork)
+            ProviderContract.getProviderClient(applicationContext, FEATURED_ART_AUTHORITY)
+                    .addArtwork(artwork)
         } catch (e: JSONException) {
             Log.e(TAG, "Error reading JSON", e)
             return Result.RETRY

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/ChosenPhotoDao.kt
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/ChosenPhotoDao.kt
@@ -249,7 +249,7 @@ internal abstract class ChosenPhotoDao {
     ) = coroutineScope  {
         chosenPhotos.map { chosenPhoto ->
             async {
-                val contentUri = ProviderContract.Artwork.getContentUri(GALLERY_ART_AUTHORITY)
+                val contentUri = ProviderContract.getContentUri(GALLERY_ART_AUTHORITY)
                 context.contentResolver.delete(contentUri,
                         "${ProviderContract.Artwork.METADATA}=?",
                         arrayOf(chosenPhoto.uri.toString()))

--- a/source-single/src/main/java/com/google/android/apps/muzei/single/SingleArtProvider.kt
+++ b/source-single/src/main/java/com/google/android/apps/muzei/single/SingleArtProvider.kt
@@ -53,7 +53,7 @@ class SingleArtProvider : MuzeiArtProvider() {
         suspend fun setArtwork(context: Context, artworkUri: Uri): Boolean {
             val tempFile = writeUriToFile(context, artworkUri, getArtworkFile(context))
             if (tempFile != null) {
-                ProviderContract.Artwork.setArtwork(context, SINGLE_AUTHORITY,
+                ProviderContract.getProviderClient(context, SINGLE_AUTHORITY).setArtwork(
                         Artwork().apply {
                             title = getDisplayName(context, artworkUri)
                                     ?: context.getString(R.string.single_default_artwork_title)

--- a/source-single/src/main/java/com/google/android/apps/muzei/single/SingleSettingsActivity.kt
+++ b/source-single/src/main/java/com/google/android/apps/muzei/single/SingleSettingsActivity.kt
@@ -54,7 +54,7 @@ class SingleSettingsActivity : Activity() {
             GlobalScope.launch {
                 val success = SingleArtProvider.setArtwork(
                         this@SingleSettingsActivity, uri)
-                setResult(if (success == true) Activity.RESULT_OK else Activity.RESULT_CANCELED)
+                setResult(if (success) Activity.RESULT_OK else Activity.RESULT_CANCELED)
                 finish()
             }
         } ?: run {

--- a/wearable/src/main/java/com/google/android/apps/muzei/datalayer/DataLayerLoadWorker.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/datalayer/DataLayerLoadWorker.kt
@@ -105,8 +105,8 @@ class DataLayerLoadWorker(
                     PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
                     PackageManager.DONT_KILL_APP)
             val artwork = dataMap.getDataMap("artwork").toArtwork()
-            val artworkUri = ProviderContract.Artwork.setArtwork(applicationContext,
-                    DATA_LAYER_AUTHORITY, artwork)
+            val artworkUri = ProviderContract.getProviderClient(applicationContext,
+                    DATA_LAYER_AUTHORITY).setArtwork(artwork)
             if (artworkUri != null) {
                 if (BuildConfig.DEBUG) {
                     Log.d(TAG, "Successfully wrote artwork to $artworkUri")


### PR DESCRIPTION
Instead of keeping a duplicate of each static method in ProviderClient (one using a Class and another using an authority String), create a new interface called ProviderClient that encapsulates all of the static methods.

MuzeiArtProvider itself implements ProviderClient, while instances can be created from new static methods on ProviderContract.