### PR TITLE
Provide an addArtwork API that takes multiple Artwork

### DIFF
--- a/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashExampleWorker.kt
+++ b/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashExampleWorker.kt
@@ -64,7 +64,7 @@ class UnsplashExampleWorker(
         val providerClient = ProviderContract.getProviderClient(
                 applicationContext, UNSPLASH_AUTHORITY)
         val attributionString = applicationContext.getString(R.string.attribution)
-        photos.map { photo ->
+        providerClient.addArtwork(photos.map { photo ->
             Artwork().apply {
                 token = photo.id
                 title = photo.description ?: attributionString
@@ -74,9 +74,7 @@ class UnsplashExampleWorker(
                 webUri = photo.links.webUri
                 metadata = photo.user.links.webUri.toString()
             }
-        }.forEach { artwork ->
-            providerClient.addArtwork(artwork)
-        }
+        })
         return Result.SUCCESS
     }
 }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.java
@@ -311,6 +311,26 @@ public abstract class MuzeiArtProvider extends ContentProvider implements Provid
     }
 
     @Override
+    @NonNull
+    public List<Uri> addArtwork(@NonNull final Iterable<Artwork> artwork) {
+        ArrayList<ContentProviderOperation> operations = new ArrayList<>();
+        for (com.google.android.apps.muzei.api.provider.Artwork art : artwork) {
+            operations.add(ContentProviderOperation.newInsert(contentUri)
+                    .withValues(art.toContentValues())
+                    .build());
+        }
+        ArrayList<Uri> resultUris = new ArrayList<>(operations.size());
+        try {
+            ContentProviderResult[] results = applyBatch(operations);
+            for (ContentProviderResult result : results) {
+                resultUris.add(result.uri);
+            }
+        } catch (OperationApplicationException ignored) {
+        }
+        return resultUris;
+    }
+
+    @Override
     @Nullable
     public final Uri setArtwork(@NonNull Artwork artwork) {
         ArrayList<ContentProviderOperation> operations = new ArrayList<>();

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
@@ -21,6 +21,8 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.List;
+
 /**
  * Interface for interacting with a {@link MuzeiArtProvider}. Methods of this interface can
  * be used directly within a MuzeiArtProvider or you can get an instance via
@@ -53,6 +55,15 @@ public interface ProviderClient {
      */
     @Nullable
     Uri addArtwork(@NonNull Artwork artwork);
+
+    /**
+     * Add multiple artwork as a batch operation to the {@link MuzeiArtProvider}.
+     *
+     * @param artwork The artwork to add
+     * @return The URIs of the newly added artwork or an empty List if the insert failed.
+     */
+    @NonNull
+    List<Uri> addArtwork(@NonNull Iterable<Artwork> artwork);
 
     /**
      * Set the {@link MuzeiArtProvider} to only show the given artwork, deleting any other


### PR DESCRIPTION
Rather than inserting each Artwork one at a time, allow MuzeiArtProvider developers to bulk insert Artwork.