### PR TITLE
Provide an setArtwork API that takes multiple Artwork

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/ProviderClient.java
@@ -75,4 +75,15 @@ public interface ProviderClient {
      */
     @Nullable
     Uri setArtwork(@NonNull Artwork artwork);
+
+    /**
+     * Set the {@link MuzeiArtProvider} to only show the given artwork, deleting any other
+     * artwork previously added. Only in the cases where the artwork is successfully inserted
+     * will the other artwork be removed.
+     *
+     * @param artwork The artwork to set
+     * @return The URIs of the newly set artwork or an empty List if the inserts failed.
+     */
+    @NonNull
+    List<Uri> setArtwork(@NonNull Iterable<Artwork> artwork);
 }


### PR DESCRIPTION
Rather than having MuzeiArtProvider developers bulk insert artwork and then have to manually diff their MuzeiArtProvider to delete no longer valid artwork, provide a setArtwork method that takes multiple artwork.

Provides an easy mechanism to handle the problem in #584