### PR TITLE
Replace openArtworkInfo() with getArtworkInfo()

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/sources/SourceArtProvider.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/sources/SourceArtProvider.kt
@@ -17,6 +17,7 @@
 package com.google.android.apps.muzei.sources
 
 import android.annotation.SuppressLint
+import android.app.PendingIntent
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.util.Log
@@ -115,31 +116,23 @@ class SourceArtProvider : MuzeiArtProvider() {
         }
     }
 
-    override fun openArtworkInfo(artwork: Artwork): Boolean {
-        val context = context ?: return false
-        val webUri = artwork.webUri ?: return false
+    override fun getArtworkInfo(artwork: Artwork): PendingIntent? {
+        val context = context ?: return null
+        val webUri = artwork.webUri ?: return null
         try {
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Opening artwork info for ${artwork.id}")
             }
             // Try to parse the metadata as an Intent
             Intent.parseUri(webUri.toString(), Intent.URI_INTENT_SCHEME)?.run {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 // Make sure any data URIs granted to Muzei are passed onto the started Activity
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                try {
-                    context.startActivity(this)
-                    return true
-                } catch (e: RuntimeException) {
-                    // Catch ActivityNotFoundException, SecurityException,
-                    // and FileUriExposedException
-                    Log.w(TAG, "Unable to start view Intent ${this}", e)
-                }
+                return PendingIntent.getActivity(context, 0, this, 0)
             }
         } catch (e: URISyntaxException) {
             Log.i(TAG, "Unable to parse viewIntent ${this}", e)
         }
-        return false
+        return null
     }
 
     override fun openFile(artwork: Artwork) =

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/ProtocolConstants.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/internal/ProtocolConstants.java
@@ -39,6 +39,7 @@ public class ProtocolConstants {
     private static final String PREFIX = "com.google.android.apps.muzei.api.";
     public static final String METHOD_GET_VERSION = PREFIX + "GET_VERSION";
     public static final String KEY_VERSION = PREFIX + "VERSION";
+    public static final int DEFAULT_VERSION = 310000;
     public static final String METHOD_REQUEST_LOAD = PREFIX + "REQUEST_LOAD";
     public static final String METHOD_MARK_ARTWORK_INVALID = PREFIX + "MARK_ARTWORK_INVALID";
     public static final String METHOD_MARK_ARTWORK_LOADED = PREFIX + "MARK_ARTWORK_LOADED";
@@ -54,6 +55,9 @@ public class ProtocolConstants {
     public static final String KEY_COMMAND = PREFIX + "COMMAND";
     public static final String METHOD_OPEN_ARTWORK_INFO = PREFIX + "OPEN_ARTWORK_INFO";
     public static final String KEY_OPEN_ARTWORK_INFO_SUCCESS = PREFIX + "ARTWORK_INFO_SUCCESS";
+    public static final int GET_ARTWORK_INFO_MIN_VERSION = 320000;
+    public static final String METHOD_GET_ARTWORK_INFO = PREFIX + "GET_ARTWORK_INFO";
+    public static final String KEY_GET_ARTWORK_INFO = PREFIX + "ARTWORK_INFO";
 
     private ProtocolConstants() {
     }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/Artwork.java
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/Artwork.java
@@ -219,7 +219,7 @@ public class Artwork {
 
     /**
      * Returns the artwork's web URI.
-     * This is used by default in {@link MuzeiArtProvider#openArtworkInfo(Artwork)} to
+     * This is used by default in {@link MuzeiArtProvider#getArtworkInfo(Artwork)} to
      * allow the user to view more details about the artwork.
      *
      * @return the artwork's web URI, or null if it doesn't exist
@@ -231,11 +231,11 @@ public class Artwork {
 
     /**
      * Sets the artwork's web URI. This is used by default in
-     * {@link MuzeiArtProvider#openArtworkInfo(Artwork)} to allow the user to view more details
+     * {@link MuzeiArtProvider#getArtworkInfo(Artwork)} to allow the user to view more details
      * about the artwork.
      *
      * @param webUri a Uri to more details about the artwork.
-     * @see MuzeiArtProvider#openArtworkInfo(Artwork)
+     * @see MuzeiArtProvider#getArtworkInfo(Artwork)
      */
     public void setWebUri(@Nullable Uri webUri) {
         this.webUri = webUri;
@@ -550,12 +550,12 @@ public class Artwork {
 
         /**
          * Sets the artwork's web URI. This is used by default in
-         * {@link MuzeiArtProvider#openArtworkInfo(Artwork)}
+         * {@link MuzeiArtProvider#getArtworkInfo(Artwork)}
          * to allow the user to view more details about the artwork.
          *
          * @param webUri a Uri to more details about the artwork.
          * @return this {@link Builder}.
-         * @see MuzeiArtProvider#openArtworkInfo(Artwork)
+         * @see MuzeiArtProvider#getArtworkInfo(Artwork)
          */
         @NonNull
         public Builder webUri(@Nullable Uri webUri) {

--- a/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtProvider.kt
+++ b/source-gallery/src/main/java/com/google/android/apps/muzei/gallery/GalleryArtProvider.kt
@@ -17,8 +17,8 @@
 package com.google.android.apps.muzei.gallery
 
 import android.annotation.SuppressLint
+import android.app.PendingIntent
 import android.content.Intent
-import android.util.Log
 import androidx.core.net.toUri
 import com.google.android.apps.muzei.api.provider.Artwork
 import com.google.android.apps.muzei.api.provider.MuzeiArtProvider
@@ -27,10 +27,6 @@ import java.io.IOException
 import java.io.InputStream
 
 class GalleryArtProvider: MuzeiArtProvider() {
-    companion object {
-        private const val TAG = "GalleryArtProvider"
-    }
-
     override fun onLoadRequested(initial: Boolean) {
         GalleryScanWorker.enqueueRescan()
     }
@@ -52,20 +48,13 @@ class GalleryArtProvider: MuzeiArtProvider() {
         }
     }
 
-    override fun openArtworkInfo(artwork: Artwork): Boolean {
-        val context = context ?: return false
-        val uri = artwork.webUri ?: artwork.persistentUri ?: return false
-        return try {
-            context.startActivity(Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(uri, "image/*")
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            })
-            true
-        } catch (e: Exception) {
-            Log.w(TAG, "Could not open artwork info for $uri", e)
-            false
-        }
+    override fun getArtworkInfo(artwork: Artwork): PendingIntent? {
+        val context = context ?: return null
+        val uri = artwork.webUri ?: artwork.persistentUri ?: return null
+        return PendingIntent.getActivity(context, 0, Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "image/*")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }, 0)
     }
 
     override fun isArtworkValid(artwork: Artwork): Boolean {

--- a/source-single/src/main/java/com/google/android/apps/muzei/single/SingleArtProvider.kt
+++ b/source-single/src/main/java/com/google/android/apps/muzei/single/SingleArtProvider.kt
@@ -17,7 +17,7 @@
 package com.google.android.apps.muzei.single
 
 import android.annotation.SuppressLint
-import android.content.ActivityNotFoundException
+import android.app.PendingIntent
 import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
@@ -140,20 +140,13 @@ class SingleArtProvider : MuzeiArtProvider() {
         // so there's never any additional artwork to load
     }
 
-    override fun openArtworkInfo(artwork: Artwork): Boolean {
-        val context = context ?: return false
+    override fun getArtworkInfo(artwork: Artwork): PendingIntent? {
+        val context = context ?: return null
         val uri = ContentUris.withAppendedId(contentUri, artwork.id)
-        return try {
-            context.startActivity(Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(uri, "image/*")
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            })
-            true
-        } catch (e: ActivityNotFoundException) {
-            Log.w(TAG, "Could not open artwork info for $uri", e)
-            false
-        }
+        return PendingIntent.getActivity(context, 0, Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "image/*")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }, 0)
     }
 
     override fun openFile(artwork: Artwork) = FileInputStream(getArtworkFile(

--- a/version.properties
+++ b/version.properties
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-apiName = 3.1.0
-apiCode = 310000
+apiName = 3.2.0-alpha01
+apiCode = 320000
 
 name = 3.1.0
 # Version number + unique ID for the build


### PR DESCRIPTION
Instead of having MuzeiArtProviders directly call startActivity from the background (which is restricted on Android Q), provide a separate getArtworkInfo() API that allows a MuzeiArtProvider to give Muzei a PendingIntent for it to launch.

Fixes #604 