### PR TITLE
Add a Legacy Source Info screen

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
@@ -188,8 +188,7 @@ class ChooseProviderFragment : Fragment(R.layout.choose_provider_fragment) {
                         }
                     })
                     setAction(R.string.legacy_action_learn_more) {
-                        startActivity(Intent(Intent.ACTION_VIEW,
-                                LegacySourceManager.LEARN_MORE_LINK))
+                        findNavController().navigate(R.id.legacy_info)
                     }
                     show()
                     // Increase the padding when the SnackBar is shown to avoid

--- a/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
@@ -44,6 +44,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
@@ -169,7 +170,7 @@ class ChooseProviderFragment : Fragment(R.layout.choose_provider_fragment) {
         }
         // Show a SnackBar whenever there are unsupported sources installed
         var snackBar: Snackbar? = null
-        LegacySourceManager.getInstance(requireContext()).unsupportedSourceCount
+        LegacySourceManager.getInstance(requireContext()).unsupportedSources.map { it.size }
                 .distinctUntilChanged().observe(viewLifecycleOwner) { count ->
             if (count > 0) {
                 snackBar = Snackbar.make(

--- a/main/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceInfoFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceInfoFragment.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.legacy
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.observe
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.apps.muzei.util.toast
+import com.google.firebase.analytics.FirebaseAnalytics
+import net.nurik.roman.muzei.R
+
+class LegacySourceInfoFragment : Fragment(R.layout.legacy_source_info_fragment) {
+    private val adapter = LegacySourceListAdapter()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = ContextCompat.getColor(
+                    requireContext(), R.color.theme_primary_dark)
+        }
+
+        val toolbar = view.findViewById<Toolbar>(R.id.legacy_source_info_toolbar)
+        toolbar.setNavigationOnClickListener {
+            findNavController().popBackStack()
+        }
+        val learnMore = view.findViewById<Button?>(R.id.legacy_source_info_learn_more)
+        if (learnMore != null) {
+            learnMore.setOnClickListener {
+                startActivity(Intent(Intent.ACTION_VIEW, LegacySourceManager.LEARN_MORE_LINK))
+            }
+        } else {
+            toolbar.inflateMenu(R.menu.legacy_source_info_fragment)
+            toolbar.setOnMenuItemClickListener {
+                startActivity(Intent(Intent.ACTION_VIEW, LegacySourceManager.LEARN_MORE_LINK))
+                true
+            }
+        }
+        val list = view.findViewById<RecyclerView>(R.id.legacy_source_info_list)
+        list.adapter = adapter
+        LegacySourceManager.getInstance(requireContext()).unsupportedSources.observe(viewLifecycleOwner) {
+            if (it.isEmpty()) {
+                requireContext().toast(R.string.legacy_source_all_uninstalled)
+                findNavController().popBackStack()
+            } else {
+                adapter.submitList(it)
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            requireActivity().window.statusBarColor = Color.TRANSPARENT
+        }
+    }
+
+    inner class LegacySourceViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val infoIcon: ImageView = itemView.findViewById(R.id.legacy_source_info_icon)
+        private val infoTitle: TextView = itemView.findViewById(R.id.legacy_source_info_title)
+        private val infoAppInfo: Button = itemView.findViewById(R.id.legacy_source_info_app_info)
+        private val infoSendFeedback: Button = itemView.findViewById(R.id.legacy_source_info_send_feedback)
+
+        fun bind(legacySourceInfo: LegacySourceInfo) = legacySourceInfo.run {
+            infoIcon.setImageBitmap(icon)
+            infoTitle.text = title
+            infoAppInfo.setOnClickListener {
+                FirebaseAnalytics.getInstance(requireContext()).logEvent(
+                        "legacy_source_info_app_info_open", bundleOf(
+                        FirebaseAnalytics.Param.ITEM_ID to packageName,
+                        FirebaseAnalytics.Param.ITEM_NAME to title))
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                intent.data = "package:$packageName".toUri()
+                startActivity(intent)
+            }
+            val intent = Intent(Intent.ACTION_VIEW,
+                    "https://play.google.com/store/apps/details?id=$packageName".toUri())
+            infoSendFeedback.isVisible =
+                    intent.resolveActivity(requireContext().packageManager) != null
+            infoSendFeedback.setOnClickListener {
+                FirebaseAnalytics.getInstance(requireContext()).logEvent(
+                        "legacy_source_info_send_feedback_open", bundleOf(
+                        FirebaseAnalytics.Param.ITEM_ID to packageName,
+                        FirebaseAnalytics.Param.ITEM_NAME to title))
+                startActivity(intent)
+            }
+        }
+    }
+
+    inner class LegacySourceListAdapter : ListAdapter<LegacySourceInfo, LegacySourceViewHolder>(
+            object : DiffUtil.ItemCallback<LegacySourceInfo>() {
+                override fun areItemsTheSame(
+                        legacySourceInfo1: LegacySourceInfo,
+                        legacySourceInfo2: LegacySourceInfo
+                ) = legacySourceInfo1.packageName == legacySourceInfo2.packageName
+
+                override fun areContentsTheSame(
+                        legacySourceInfo1: LegacySourceInfo,
+                        legacySourceInfo2: LegacySourceInfo
+                ) = legacySourceInfo1 == legacySourceInfo2
+            }
+    ) {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+                LegacySourceViewHolder(layoutInflater.inflate(
+                        R.layout.legacy_source_info_item, parent, false))
+
+        override fun onBindViewHolder(holder: LegacySourceViewHolder, position: Int) {
+            holder.bind(getItem(position))
+        }
+    }
+}

--- a/main/src/main/res/layout-w540dp/legacy_source_info_fragment.xml
+++ b/main/src/main/res/layout-w540dp/legacy_source_info_fragment.xml
@@ -1,0 +1,61 @@
+<!--
+  Copyright 2019 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/browse_provider_background"
+    android:fitsSystemWindows="true"
+    app:statusBarBackground="@color/theme_primary_dark">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:fitsSystemWindows="true">
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/legacy_source_info_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?actionBarSize"
+                app:navigationIcon="?attr/homeAsUpIndicator"
+                app:title="@string/legacy_source_info_title"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="16dp"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="@dimen/legacy_source_info_padding"
+                android:text="@string/legacy_source_info_subtitle"/>
+        </LinearLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/legacy_source_info_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="@dimen/legacy_source_info_padding"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/main/src/main/res/layout/legacy_source_info_fragment.xml
+++ b/main/src/main/res/layout/legacy_source_info_fragment.xml
@@ -1,0 +1,70 @@
+<!--
+  Copyright 2019 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/browse_provider_background"
+    android:fitsSystemWindows="true"
+    app:statusBarBackground="@color/theme_primary_dark">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:fitsSystemWindows="true">
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/legacy_source_info_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?actionBarSize"
+                app:navigationIcon="?attr/homeAsUpIndicator"
+                app:title="@string/legacy_source_info_title"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/legacy_source_info_padding"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="@dimen/legacy_source_info_padding"
+                android:text="@string/legacy_source_info_subtitle"/>
+            <Button
+                android:id="@+id/legacy_source_info_learn_more"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/legacy_source_info_padding"
+                android:layout_marginEnd="@dimen/legacy_source_info_padding"
+                android:textColor="@android:color/white"
+                android:text="@string/legacy_action_learn_more"/>
+        </LinearLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/legacy_source_info_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="@dimen/legacy_source_info_padding"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/main/src/main/res/layout/legacy_source_info_item.xml
+++ b/main/src/main/res/layout/legacy_source_info_item.xml
@@ -1,0 +1,107 @@
+<!--
+  Copyright 2019 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="480dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/legacy_source_info_icon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:importantForAccessibility="no"
+                android:scaleType="centerCrop"
+                app:layout_constraintBottom_toTopOf="@+id/legacy_source_info_button_bar"
+                app:layout_constraintEnd_toStartOf="@+id/legacy_source_info_title"
+                app:layout_constraintHorizontal_chainStyle="spread_inside"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="spread_inside"
+                app:srcCompat="@mipmap/ic_launcher" />
+
+            <TextView
+                android:id="@+id/legacy_source_info_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
+                android:lines="1"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                app:layout_constraintBottom_toBottomOf="@+id/legacy_source_info_icon"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/legacy_source_info_icon"
+                app:layout_constraintTop_toTopOf="@+id/legacy_source_info_icon"
+                tools:text="Label" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/legacy_source_info_button_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="top"
+                app:constraint_referenced_ids="legacy_source_info_app_info,legacy_source_info_send_feedback" />
+
+            <Button
+                android:id="@+id/legacy_source_info_app_info"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/legacy_source_info_app_info"
+                android:textColor="?android:attr/textColorPrimary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/legacy_source_info_send_feedback"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/legacy_source_info_button_bar" />
+
+            <Button
+                android:id="@+id/legacy_source_info_send_feedback"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:text="@string/legacy_source_info_send_feedback"
+                android:textColor="?android:attr/textColorPrimary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/legacy_source_info_app_info"
+                app:layout_constraintTop_toBottomOf="@+id/legacy_source_info_button_bar" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/main/src/main/res/menu/legacy_source_info_fragment.xml
+++ b/main/src/main/res/menu/legacy_source_info_fragment.xml
@@ -1,0 +1,24 @@
+<!--
+  Copyright 2019 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/legacy_source_info_learn_more"
+        android:title="@string/legacy_action_learn_more"
+        app:showAsAction="withText|ifRoom"/>
+</menu>

--- a/main/src/main/res/navigation/main_navigation.xml
+++ b/main/src/main/res/navigation/main_navigation.xml
@@ -50,6 +50,13 @@
             app:exitAnim="@anim/nav_default_exit_anim"
             app:popEnterAnim="@anim/nav_default_pop_enter_anim"
             app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+        <action
+            android:id="@+id/legacy_info"
+            app:destination="@+id/legacy_source_info"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
     </fragment>
     <fragment
         android:id="@+id/browse_provider"
@@ -59,6 +66,10 @@
             android:name="contentUri"
             app:argType="android.net.Uri"/>
     </fragment>
+    <fragment
+        android:id="@+id/legacy_source_info"
+        android:name="com.google.android.apps.muzei.legacy.LegacySourceInfoFragment"
+        tools:layout="@layout/legacy_source_info_fragment"/>
     <fragment
         android:id="@+id/main_effects"
         android:name="com.google.android.apps.muzei.settings.EffectsFragment"

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -32,6 +32,8 @@
 
     <dimen name="tutorial_content_margin">32dp</dimen>
 
+    <dimen name="legacy_source_info_padding">8dp</dimen>
+
     <dimen name="provider_padding">8dp</dimen>
     <dimen name="provider_padding_with_snackbar">56dp</dimen>
     <dimen name="settings_text_size_large">20sp</dimen>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -84,6 +84,12 @@
         <item quantity="one">%d unsupported source found</item>
         <item quantity="other">%d unsupported sources found</item>
     </plurals>
+    <string name="legacy_source_info_title">Legacy Sources</string>
+    <string name="legacy_source_info_subtitle">Sources built with the Legacy Source API are
+        no longer directly supported by Muzei.</string>
+    <string name="legacy_source_info_app_info">App info</string>
+    <string name="legacy_source_info_send_feedback">Send feedback</string>
+    <string name="legacy_source_all_uninstalled">All Legacy Sources have been uninstalled</string>
 
     <string name="done">Done</string>
 


### PR DESCRIPTION
Let users get a list of legacy sources they have installed with links to the app info screen for each along with a link to Google Play to send the developer of the legacy source feedback.

Fixes #615 