### PR TITLE
Prepare strings.xml files for translation

### DIFF
--- a/android-client-common/src/main/res/values/strings.xml
+++ b/android-client-common/src/main/res/values/strings.xml
@@ -15,6 +15,6 @@
   -->
 
 <resources>
-    <string name="app_name">Muzei</string>
+    <string name="app_name" translatable="false">Muzei</string>
     <string name="error_view_details">Couldn\'t view artwork details.</string>
 </resources>

--- a/example-unsplash/src/main/res/values/strings.xml
+++ b/example-unsplash/src/main/res/values/strings.xml
@@ -14,12 +14,25 @@
   limitations under the License.
   -->
 
-<resources>
-    <string name="app_name">Unsplash (Example Muzei Source)</string>
-    <string name="name">Unsplash (Example)</string>
-    <string name="description">Popular photos from Unsplash</string>
-    <string name="attribution">Photo on Unsplash</string>
-    <string name="action_view_profile">View %s\'s profile</string>
-    <string name="action_visit_unsplash">Visit Unsplash</string>
-    <string name="unsplash_link">https://unsplash.com/</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">
+        <xliff:g id="unsplash_name">Unsplash</xliff:g>
+        (Example <xliff:g id="muzei_name">Muzei</xliff:g> Source)
+    </string>
+    <string name="name">
+        <xliff:g id="unsplash_name">Unsplash</xliff:g> (Example)
+    </string>
+    <string name="description">
+        Popular photos from <xliff:g id="unsplash_name">Unsplash</xliff:g>
+    </string>
+    <string name="attribution">
+        Photo on <xliff:g id="unsplash_name">Unsplash</xliff:g>
+    </string>
+    <string name="action_view_profile">
+        View <xliff:g id="user_name" example="ilake">%s</xliff:g>\'s profile
+    </string>
+    <string name="action_visit_unsplash">
+        Visit <xliff:g id="unsplash_name">Unsplash</xliff:g>
+    </string>
+    <string name="unsplash_link" translatable="false">https://unsplash.com/</string>
 </resources>

--- a/example-watchface/src/main/res/values/strings.xml
+++ b/example-watchface/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
   limitations under the License.
   -->
 
-<resources>
-    <string name="app_name">Muzei Example</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">
+        <xliff:g id="muzei_name">Muzei</xliff:g> Example
+    </string>
 </resources>

--- a/legacy-standalone/src/main/res/values-v23/strings.xml
+++ b/legacy-standalone/src/main/res/values-v23/strings.xml
@@ -14,13 +14,14 @@
   limitations under the License.
   -->
 
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="legacy_source_warning_message">There are known issues with Legacy Sources on your device.
         You must disable Battery Optimizations on any Legacy Source you select to ensure it can
         load wallpapers. This may cause additional battery drain.\n\n
         In addition, Legacy Sources load on their own schedule and don\'t use Auto Advance.
         This may lead to additional data usage if the Legacy Source does not have its own WiFi
         only setting.\n\n
-        Support for Legacy Sources will be removed in early 2019 due to Google Play Store
-        targetSdkVersion requirements.</string>
+        Support for Legacy Sources will be removed in early 2019 due to
+        <xliff:g id="google_play">Google Play</xliff:g> Store
+        <xliff:g id="targetSdkVersion">targetSdkVersion</xliff:g> requirements.</string>
 </resources>

--- a/legacy-standalone/src/main/res/values/strings.xml
+++ b/legacy-standalone/src/main/res/values/strings.xml
@@ -14,8 +14,10 @@
   limitations under the License.
   -->
 
-<resources>
-    <string name="legacy_app_name">Muzei Legacy</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="legacy_app_name">
+        <xliff:g id="muzei_name">Muzei</xliff:g> Legacy
+    </string>
     <string name="legacy_source_provider_name">Legacy Sources</string>
 
     <string name="legacy_source_warning_title">Activate a Legacy Source?</string>
@@ -32,8 +34,14 @@
     <string name="legacy_source_unavailable">Your selected source is unavailable. Switching to the default source.</string>
 
     <string name="legacy_source_target_too_high_title">This source is disabled</string>
-    <string name="legacy_source_target_too_high_message">%s is incompatible with Muzei\'s API. To use this source, the developer must change their targetSdkVersion to 25 or lower.</string>
-    <string name="legacy_source_target_too_high_send_feedback">Send %s feedback</string>
+    <string name="legacy_source_target_too_high_message">
+        <xliff:g id="source_name" example="Nice Wallpapers">%s</xliff:g> is incompatible with
+        <xliff:g id="muzei_name">Muzei</xliff:g>\'s API. To use this source, the developer must
+        change their <xliff:g id="targetSdkVersion">targetSdkVersion</xliff:g> to 25 or lower.
+    </string>
+    <string name="legacy_source_target_too_high_send_feedback">
+        Send <xliff:g id="source_name" example="Nice Wallpapers">%s</xliff:g> feedback
+    </string>
     <string name="legacy_source_target_too_high_learn_more">Learn more</string>
     <string name="legacy_source_target_too_high_dismiss">Got it</string>
 </resources>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -14,10 +14,14 @@
   limitations under the License.
   -->
 
-<resources>
-    <string name="app_description">Muzei Live Wallpaper</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_description">
+        <xliff:g id="muzei_name">Muzei</xliff:g> Live Wallpaper
+    </string>
 
-    <string name="settings_title">Muzei Settings</string>
+    <string name="settings_title">
+        <xliff:g id="muzei_name">Muzei</xliff:g> Settings
+    </string>
     <string name="settings_home_screen_title">Home Screen</string>
     <string name="settings_lock_screen_title">Lock Screen</string>
     <string name="settings_blur_amount_title">Blur</string>
@@ -27,8 +31,11 @@
     <string name="notification_new_wallpaper">New wallpaper</string>
     <string name="notification_new_wallpaper_channel_name">New wallpapers</string>
     <string name="notification_settings">Notification Settings</string>
-    <string name="notification_settings_failed">Opening notification settings failed,
-        please adjust Muzei\'s notification settings from the Settings app.</string>
+    <string name="notification_settings_failed">
+        Opening notification settings failed,
+        please adjust <xliff:g id="muzei_name">Muzei</xliff:g>\'s notification settings
+        from the Settings app.
+    </string>
     <string name="notification_settings_done">Done</string>
     <string name="notification_settings_moved_title">Notification settings have moved</string>
     <string name="notification_settings_moved_text">Review your notification settings</string>
@@ -38,8 +45,10 @@
     <string name="auto_advance_disabled_description">Legacy Sources handle their own
         wallpaper loading and do not support Auto Advance</string>
     <string name="auto_advance_title">Auto Advance</string>
-    <string name="auto_advance_description">Control when Muzei automatically advances to the next
-        wallpaper.</string>
+    <string name="auto_advance_description">
+        Control when <xliff:g id="muzei_name">Muzei</xliff:g> automatically advances to the next
+        wallpaper.
+    </string>
     <string name="auto_advance_wifi">Auto advance only on Wi-Fi</string>
     <string name="auto_advance_interval">Interval</string>
     <string name="auto_advance_interval_15m">Every 15 minutes</string>
@@ -50,11 +59,18 @@
     <string name="auto_advance_interval_24h">Every 24 hours</string>
     <string name="auto_advance_interval_72h">Every 3 days</string>
     <string name="auto_advance_interval_never">Don\'t auto advance</string>
-    <string name="auto_advance_tasker">For exact control over what triggers your wallpaper to change, use the \'Next artwork\' action available in Tasker under Plugin -> Muzei and disable auto advance here.</string>
+    <string name="auto_advance_tasker">
+        For exact control over what triggers your wallpaper to change, use the
+        \'Next artwork\' action available in
+        <xliff:g id="tasker_name">Tasker</xliff:g> under Plugin ->
+        <xliff:g id="muzei_name">Muzei</xliff:g> and disable auto advance here.</string>
 
     <string name="action_activate">Activate</string>
     <string name="error_view_details">Couldn\'t view artwork details.</string>
-    <string name="error_wallpaper_chooser">Couldn\'t launch wallpaper chooser. You can still activate Muzei by choosing \'Live Wallpapers\' in your home screen wallpaper picker.</string>
+    <string name="error_wallpaper_chooser">
+        Couldn\'t launch wallpaper chooser. You can still activate
+        <xliff:g id="muzei_name">Muzei</xliff:g> by choosing
+        \'Live Wallpapers\' in your home screen wallpaper picker.</string>
 
     <string name="section_choose_source">Sources</string>
     <string name="section_effects">Effects</string>
@@ -70,56 +86,92 @@
     <string name="provider_browse">Browse</string>
 
     <string name="legacy_notification_channel_name">Legacy Sources</string>
-    <string name="legacy_notification_title">%s is no longer supported</string>
-    <string name="legacy_notification_text">Muzei does not directly support sources built
-        with the Legacy Source API.</string>
+    <string name="legacy_notification_title">
+        <xliff:g id="source_name" example="Nice Wallpapers">%s</xliff:g> is no longer supported
+    </string>
+    <string name="legacy_notification_text">
+        <xliff:g id="muzei_name">Muzei</xliff:g> does not directly support sources built
+        with the Legacy Source API.
+    </string>
     <string name="legacy_action_learn_more">Learn more</string>
     <string name="legacy_action_send_feedback">Send feedback</string>
     <string name="legacy_summary_title">Legacy Sources are no longer supported</string>
     <plurals name="legacy_summary_text">
-        <item quantity="one">%d Legacy Source found</item>
-        <item quantity="other">%d Legacy Sources found</item>
+        <item quantity="one">
+            <xliff:g id="quantity" example="1">%1$d</xliff:g> Legacy Source found
+        </item>
+        <item quantity="other">
+            <xliff:g id="quantity" example="2">%1$d</xliff:g> Legacy Sources found
+        </item>
     </plurals>
     <plurals name="legacy_unsupported_text">
-        <item quantity="one">%d unsupported source found</item>
-        <item quantity="other">%d unsupported sources found</item>
+        <item quantity="one">
+            <xliff:g id="quantity" example="1">%1$d</xliff:g> unsupported source found
+        </item>
+        <item quantity="other">
+            <xliff:g id="quantity" example="2">%1$d</xliff:g> unsupported sources found
+        </item>
     </plurals>
     <string name="legacy_source_info_title">Legacy Sources</string>
-    <string name="legacy_source_info_subtitle">Sources built with the Legacy Source API are
-        no longer directly supported by Muzei.</string>
+    <string name="legacy_source_info_subtitle">
+        Sources built with the Legacy Source API are
+        no longer directly supported by <xliff:g id="muzei_name">Muzei</xliff:g>.
+    </string>
     <string name="legacy_source_info_app_info">App info</string>
     <string name="legacy_source_info_send_feedback">Send feedback</string>
     <string name="legacy_source_all_uninstalled">All Legacy Sources have been uninstalled</string>
 
     <string name="done">Done</string>
 
-    <string name="set_as_wallpaper_using_muzei">Wallpaper (using Muzei)</string>
+    <string name="set_as_wallpaper_using_muzei">
+        Wallpaper (using <xliff:g id="muzei_name">Muzei</xliff:g>)
+    </string>
     <string name="set_as_wallpaper_failed">Unable to read artwork</string>
 
-    <string name="tutorial_main">Open the Muzei app to see your wallpaper</string>
+    <string name="tutorial_main">
+        Open the <xliff:g id="muzei_name">Muzei</xliff:g> app to see your wallpaper
+    </string>
     <string name="tutorial_subtitle">Double touch the blurred wallpaper on your home screen to temporarily focus</string>
 
     <string name="get_more_sources">Get more sources</string>
-    <string name="get_more_sources_description">Change your wallpaper entirely with
-        additional sources installed from the Google Play Store</string>
+    <string name="get_more_sources_description">
+        Change your wallpaper entirely with additional sources installed from the
+        <xliff:g id="google_play">Google Play</xliff:g> Store
+    </string>
     <string name="action_link_effects">Home 🔗 Lock</string>
     <string name="toast_link_effects">Home &amp; Lock screen effects are now linked</string>
     <string name="action_link_effects_off">Home &amp; Lock aren\'t linked together</string>
     <string name="toast_link_effects_off">Home &amp; Lock screen effects are no longer linked together</string>
     <string name="reset_advanced_settings_defaults">Reset sliders</string>
-    <string name="play_store_not_found">Unable to open Play Store.</string>
+    <string name="play_store_not_found">
+        Unable to open <xliff:g id="google_play">Google Play</xliff:g> Store.
+    </string>
 
     <string name="browse_refresh">Refresh</string>
     <string name="browse_set_wallpaper">Set the current wallpaper</string>
-    <string name="browse_set_wallpaper_with_title">Set the current wallpaper to \"%s\"</string>
+    <string name="browse_set_wallpaper_with_title">
+        Set the current wallpaper to
+        \"<xliff:g id="image_name" example="IMG14227.jpg">%s</xliff:g>\"
+    </string>
 
-    <string name="missing_resources_title">Invalid Muzei installation</string>
-    <string name="missing_resources_message">Muzei is in an invalid state. Please uninstall Muzei and install it from the Google Play Store to repair your installation.</string>
-    <string name="missing_resources_open">Open Play Store</string>
-    <string name="missing_resources_quit">Close Muzei</string>
+    <string name="missing_resources_title">
+        Invalid <xliff:g id="muzei_name">Muzei</xliff:g> installation
+    </string>
+    <string name="missing_resources_message">
+        <xliff:g id="muzei_name">Muzei</xliff:g> is in an invalid state.
+        Please uninstall <xliff:g id="muzei_name">Muzei</xliff:g> and install it from the
+        <xliff:g id="google_play">Google Play</xliff:g> Store to repair your installation.</string>
+    <string name="missing_resources_open">
+        Open <xliff:g id="google_play">Google Play</xliff:g> Store
+    </string>
+    <string name="missing_resources_quit">
+        Close <xliff:g id="muzei_name">Muzei</xliff:g>
+    </string>
 
     <string name="tasker_setting_dialog_title">Select action</string>
-    <string name="tasker_action_select_provider">Select %s</string>
+    <string name="tasker_action_select_provider">
+        Select <xliff:g id="source_name" example="Nice Wallpapers">%s</xliff:g>
+    </string>
 
     <string name="actions_gestures">Customize Gestures</string>
     <string name="gestures_title">Gestures</string>
@@ -136,7 +188,9 @@
 
     <string name="actions_always_dark">Always Dark</string>
 
-    <string name="about_title">About Muzei</string>
+    <string name="about_title">
+        About <xliff:g id="muzei_name">Muzei</xliff:g>
+    </string>
     <string name="about_body"><![CDATA[
         Made by Roman Nurik and Ian Lake, with major contributions from
         the <a href="http://code.muzei.co">open source community</a>.
@@ -152,8 +206,13 @@
         &bull; <b><a href="http://square.github.io/okhttp/">OkHttp</a> and <a href="http://square.github.io/picasso/">Picasso</a></b> by Square<br>
         &bull; <b><a href="https://github.com/GLWallpaperService/GLWallpaperService">GLWallpaperService</a></b> by Robert Green, Mark F. Guerra, and others
     ]]></string>
-    <string name="about_version_template">v%1$s</string>
-    <string name="app_author">Roman Nurik and Ian Lake</string>
+    <string name="about_version_template">
+        v<xliff:g id="version_number" example="3.3.0 Beta">%1$s</xliff:g>
+    </string>
+    <string name="app_author">
+        <xliff:g id="roman_nurik">Roman Nurik</xliff:g> and
+        <xliff:g id="ian_lake">Ian Lake</xliff:g>
+    </string>
     <string name="app_context_description">A living museum for your home screen</string>
-    <string name="app_context_uri">http://www.muzei.co/</string>
+    <string name="app_context_uri" translatable="false">http://www.muzei.co/</string>
 </resources>

--- a/source-gallery/src/main/res/values/strings.xml
+++ b/source-gallery/src/main/res/values/strings.xml
@@ -14,10 +14,12 @@
   limitations under the License.
   -->
 
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="gallery_add_fab">Add photos</string>
     <string name="gallery_add_photos">Add photos</string>
-    <string name="gallery_add_folder">Import photos from %s</string>
+    <string name="gallery_add_folder">
+        Import photos from <xliff:g id="app_name" example="Gallery">%s</xliff:g>
+    </string>
     <string name="gallery_internal_storage_message">Don\'t see anything? Try enabling internal storage in the overflow
         menu</string>
     <string name="gallery_add_photos_error">Your device does not support adding pictures.\nPlease contact your manufacturer.</string>
@@ -25,7 +27,9 @@
 
     <string name="gallery_action_clear_photos">Remove all photos</string>
     <string name="gallery_action_import_photos">Import photos…</string>
-    <string name="gallery_action_import_photos_from">Import photos from %s</string>
+    <string name="gallery_action_import_photos_from">
+        Import photos from <xliff:g id="app_name" example="Gallery">%s</xliff:g>
+    </string>
 
     <string name="gallery_import_dialog_title">Import photos from</string>
 
@@ -34,21 +38,39 @@
     <string name="gallery_title">My Photos</string>
     <string name="gallery_description">Random camera photos</string>
     <plurals name="gallery_description_choice_template">
-        <item quantity="one">1 photo</item>
-        <item quantity="other">%1$d photos</item>
+        <item quantity="one">
+            <xliff:g id="quantity" example="1">%1$d</xliff:g> photo
+        </item>
+        <item quantity="other">
+            <xliff:g id="quantity" example="2">%1$d</xliff:g> photos
+        </item>
     </plurals>
     <string name="gallery_empty">Random camera photos</string>
     <string name="gallery_empty_subtitle">Choose specific photos instead</string>
     <string name="gallery_from_gallery">From your gallery</string>
     <string name="gallery_touch_to_view">Touch to view</string>
-    <string name="gallery_shared_from">Shared from %s</string>
+    <string name="gallery_shared_from">
+        Shared from <xliff:g id="app_name" example="Gallery">%s</xliff:g>
+    </string>
     <plurals name="gallery_add_photos_success">
-        <item quantity="one">Successfully added the image\nto the \"My Photos\" source</item>
-        <item quantity="other">Successfully added %d images\nto the \"My Photos\" source</item>
+        <item quantity="one">
+            Successfully added the image\n
+            to the \"My Photos\" source
+        </item>
+        <item quantity="other">
+            Successfully added <xliff:g id="quantity" example="2">%d</xliff:g> images\n
+            to the \"My Photos\" source
+        </item>
     </plurals>
     <plurals name="gallery_add_photos_failure">
-        <item quantity="one">Unable to add the image\nto the \"My Photos\" source</item>
-        <item quantity="other">Unable to add %d images\nto the \"My Photos\" source</item>
+        <item quantity="one">
+            Unable to add the image\n
+            to the \"My Photos\" source
+        </item>
+        <item quantity="other">
+            Unable to add <xliff:g id="quantity" example="2">%d</xliff:g> images\n
+            to the \"My Photos\" source
+        </item>
     </plurals>
 
     <string name="gallery_enable_random">Enable random camera photos</string>


### PR DESCRIPTION
Add translatable="false" and <xliff:g> tags to strings and sections of strings that should not be translated due to being proper nouns or control characters.

For #647 