### PR TITLE
Show multiple commands on Wear OS devices

### DIFF
--- a/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderManager.kt
+++ b/android-client-common/src/main/java/com/google/android/apps/muzei/sync/ProviderManager.kt
@@ -61,7 +61,7 @@ internal val syncSingleThreadContext by lazy {
  * Manager which monitors the current Provider
  */
 class ProviderManager private constructor(private val context: Context)
-    : MutableLiveData<Provider>(), Observer<Provider?> {
+    : MutableLiveData<Provider?>(), Observer<Provider?> {
 
     companion object {
         private const val TAG = "ProviderManager"

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation "androidx.exifinterface:exifinterface:$exifInterfaceVersion"
     implementation "androidx.preference:preference-ktx:$preferenceVersion"
+    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.wear:wear:$wearVersion"
     compileOnly "com.google.android.wearable:wearable:$wearableVersion"
     implementation ("com.google.android.support:wearable:$wearableVersion") {

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion"
+    implementation "io.coil-kt:coil:$coilVersion"
     implementation "androidx.work:work-runtime-ktx:$workManagerVersion"
     implementation "androidx.core:core-ktx:$coreVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-core-ktx:$lifecycleVersion"

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
@@ -56,11 +56,7 @@ class MuzeiActivity : FragmentActivity(),
     private val ambientCallback: AmbientModeSupport.AmbientCallback =
             object : AmbientModeSupport.AmbientCallback() {
 
-                private var showImageOnExit = false
-
                 override fun onEnterAmbient(ambientDetails: Bundle?) {
-                    showImageOnExit = binding.artworkInfo.image.isVisible
-                    binding.artworkInfo.image.isVisible = false
                     binding.time.isVisible = true
                     updateTime()
                 }
@@ -77,7 +73,6 @@ class MuzeiActivity : FragmentActivity(),
                 }
 
                 override fun onExitAmbient() {
-                    binding.artworkInfo.image.isVisible = showImageOnExit
                     binding.time.isVisible = false
                 }
             }
@@ -144,7 +139,7 @@ class MuzeiActivity : FragmentActivity(),
                 binding.artworkInfo.image.contentDescription = artwork.title
                         ?: artwork.byline
                         ?: artwork.attribution
-                binding.artworkInfo.image.isVisible = image != null && !ambientController.isAmbient
+                binding.artworkInfo.image.isVisible = image != null
                 binding.artworkInfo.title.text = artwork.title
                 binding.artworkInfo.title.isVisible = !artwork.title.isNullOrBlank()
                 binding.artworkInfo.byline.text = artwork.byline

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
@@ -1,110 +1,36 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.apps.muzei
 
-import android.app.Application
-import android.content.ComponentName
-import android.content.Intent
-import android.content.pm.PackageManager
 import android.content.res.Resources
-import android.graphics.Rect
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.format.DateFormat
 import androidx.activity.viewModels
-import androidx.core.app.RemoteActionCompat
-import androidx.core.content.ContextCompat
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.liveData
 import androidx.lifecycle.observe
-import androidx.lifecycle.switchMap
 import androidx.wear.ambient.AmbientModeSupport
-import androidx.wear.widget.RoundedDrawable
-import coil.api.load
-import com.google.android.apps.muzei.datalayer.ActivateMuzeiIntentService
-import com.google.android.apps.muzei.featuredart.BuildConfig.FEATURED_ART_AUTHORITY
-import com.google.android.apps.muzei.room.Artwork
-import com.google.android.apps.muzei.room.MuzeiDatabase
-import com.google.android.apps.muzei.room.Provider
-import com.google.android.apps.muzei.room.getCommands
-import com.google.android.apps.muzei.sync.ProviderManager
 import com.google.android.apps.muzei.util.filterNotNull
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import net.nurik.roman.muzei.BuildConfig
-import net.nurik.roman.muzei.R
 import net.nurik.roman.muzei.databinding.MuzeiActivityBinding
 import java.text.SimpleDateFormat
 import java.util.Locale
-
-data class ArtworkCommand(
-        private val artwork: Artwork,
-        private val command: RemoteActionCompat
-) {
-    val providerAuthority = artwork.providerAuthority
-    val title = command.title
-    val actionIntent = command.actionIntent
-    val icon = command.icon
-    fun shouldShowIcon() = command.shouldShowIcon()
-}
-
-data class ProviderData(
-        private val provider: Provider,
-        val icon: Drawable,
-        val label: CharSequence,
-        val description: String,
-        val settingsActivity: ComponentName?
-) {
-    val supportsNextArtwork = provider.supportsNextArtwork
-}
-
-class MuzeiViewModel(application: Application) : AndroidViewModel(application) {
-
-    val artworkLiveData = MuzeiDatabase.getInstance(application).artworkDao().currentArtwork
-
-    val commandsLiveData = artworkLiveData.switchMap { artwork ->
-        liveData {
-            if (artwork != null) {
-                emit(artwork.getCommands(getApplication<Application>()).map { command ->
-                    ArtworkCommand(artwork, command)
-                })
-            } else {
-                emit(emptyList<ArtworkCommand>())
-            }
-        }
-    }
-
-    val providerLiveData = ProviderManager.getInstance(getApplication()).switchMap { provider ->
-        liveData {
-            val app = getApplication<Application>()
-            if (provider != null) {
-                val pm = app.packageManager
-                val providerInfo = pm.resolveContentProvider(provider.authority,
-                        PackageManager.GET_META_DATA)
-                if (providerInfo != null) {
-                    val icon = providerInfo.loadIcon(pm)
-                    val label = providerInfo.loadLabel(pm)
-                    val settingsActivity = providerInfo.metaData?.getString("settingsActivity")?.run {
-                        ComponentName(providerInfo.packageName, this)
-                    }
-                    emit(ProviderData(provider, icon, label,
-                            ProviderManager.getDescription(app, provider.authority),
-                            settingsActivity))
-                }
-            } else {
-                GlobalScope.launch {
-                    ProviderManager.select(app, FEATURED_ART_AUTHORITY)
-                    ActivateMuzeiIntentService.checkForPhoneApp(app)
-                }
-            }
-        }
-    }
-}
 
 class MuzeiActivity : FragmentActivity(),
         AmbientModeSupport.AmbientCallbackProvider {
@@ -142,7 +68,10 @@ class MuzeiActivity : FragmentActivity(),
 
     private lateinit var binding: MuzeiActivityBinding
 
-    private val viewModel: MuzeiViewModel by viewModels()
+    private val artworkViewModel: MuzeiArtworkViewModel by viewModels()
+    private val nextArtworkViewModel: MuzeiNextArtworkViewModel by viewModels()
+    private val commandViewModel: MuzeiCommandViewModel by viewModels()
+    private val providerViewModel: MuzeiProviderViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -157,63 +86,19 @@ class MuzeiActivity : FragmentActivity(),
             val inset = (FACTOR * Resources.getSystem().displayMetrics.widthPixels).toInt()
             binding.content.setPadding(inset, 0, inset, inset)
         }
-        binding.artworkInfo.image.setOnClickListener {
-            startActivity(Intent(this@MuzeiActivity,
-                    FullScreenActivity::class.java))
-        }
-        binding.nextArtwork.nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
-            isClipEnabled = true
-            radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-            backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
-                    R.color.theme_primary)
-            drawable = ContextCompat.getDrawable(this@MuzeiActivity,
-                    R.drawable.ic_next_artwork)
-            bounds = Rect(0, 0, radius * 2, radius * 2)
-        }, null, null, null)
-        binding.nextArtwork.nextArtwork.setOnClickListener {
-            ProviderManager.getInstance(this).nextArtwork()
-        }
-        binding.providerInfo.provider.setOnClickListener {
-            startActivity(Intent(this@MuzeiActivity,
-                    ChooseProviderActivity::class.java))
-        }
-        binding.providerInfo.settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
-            isClipEnabled = true
-            radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-            backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
-                    R.color.theme_primary)
-            drawable = ContextCompat.getDrawable(this@MuzeiActivity,
-                    R.drawable.ic_provider_settings)
-            bounds = Rect(0, 0, radius * 2, radius * 2)
-        }, null, null, null)
+        binding.artworkInfo.create()
+        binding.nextArtwork.create()
+        binding.providerInfo.create()
 
-        viewModel.artworkLiveData.filterNotNull().observe(this) { artwork ->
-            binding.artworkInfo.image.load(artwork.contentUri) {
-                allowHardware(false)
-                target { image ->
-                    binding.artworkInfo.image.setImageDrawable(RoundedDrawable().apply {
-                        isClipEnabled = true
-                        radius = resources.getDimensionPixelSize(R.dimen.art_detail_image_radius)
-                        drawable = image
-                    })
-                }
-                listener(
-                        onError = { _, _ -> binding.artworkInfo.image.isVisible = false },
-                        onSuccess = { _, _ -> binding.artworkInfo.image.isVisible = true }
-                )
-            }
-            binding.artworkInfo.image.contentDescription = artwork.title
-                    ?: artwork.byline
-                    ?: artwork.attribution
-            binding.artworkInfo.title.text = artwork.title
-            binding.artworkInfo.title.isVisible = !artwork.title.isNullOrBlank()
-            binding.artworkInfo.byline.text = artwork.byline
-            binding.artworkInfo.byline.isVisible = !artwork.byline.isNullOrBlank()
-            binding.artworkInfo.attribution.text = artwork.attribution
-            binding.artworkInfo.attribution.isVisible = !artwork.attribution.isNullOrBlank()
+        artworkViewModel.artworkLiveData.filterNotNull().observe(this) { artwork ->
+            binding.artworkInfo.bind(artwork)
         }
 
-        viewModel.commandsLiveData.observe(this) { commands ->
+        nextArtworkViewModel.providerLiveData.observe(this) { provider ->
+            binding.nextArtwork.nextArtwork.isVisible = provider?.supportsNextArtwork == true
+        }
+
+        commandViewModel.commandsLiveData.observe(this) { commands ->
             // TODO Show multiple commands rather than only the first
             val command = commands.filterNot { action ->
                 action.title.isBlank()
@@ -221,47 +106,15 @@ class MuzeiActivity : FragmentActivity(),
                 action.shouldShowIcon()
             }
             if (command != null) {
-                binding.command.command.text = command.title
-                binding.command.command.setCompoundDrawablesRelative(RoundedDrawable().apply {
-                    isClipEnabled = true
-                    radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-                    backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
-                            R.color.theme_primary)
-                    drawable = command.icon.loadDrawable(this@MuzeiActivity)
-                    bounds = Rect(0, 0, radius * 2, radius * 2)
-                }, null, null, null)
-                binding.command.command.setOnClickListener {
-                    Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
-                        param(FirebaseAnalytics.Param.ITEM_LIST_ID, command.providerAuthority)
-                        param(FirebaseAnalytics.Param.ITEM_NAME, command.title.toString())
-                        param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "actions")
-                        param(FirebaseAnalytics.Param.CONTENT_TYPE, "wear_activity")
-                    }
-                    command.actionIntent.send()
-                }
+                binding.command.bind(command)
                 binding.command.command.isVisible = true
             } else {
                 binding.command.command.isVisible = false
             }
         }
 
-        viewModel.providerLiveData.observe(this) { provider ->
-            binding.nextArtwork.nextArtwork.isVisible = provider.supportsNextArtwork
-            val size = resources.getDimensionPixelSize(R.dimen.choose_provider_image_size)
-            provider.icon.bounds = Rect(0, 0, size, size)
-            binding.providerInfo.provider.setCompoundDrawablesRelative(provider.icon,
-                    null, null, null)
-            binding.providerInfo.provider.text = provider.label
-            binding.providerInfo.providerDescription.isGone = provider.description.isBlank()
-            binding.providerInfo.providerDescription.text = provider.description
-            binding.providerInfo.settings.isVisible = provider.settingsActivity != null
-            binding.providerInfo.settings.setOnClickListener {
-                if (provider.settingsActivity != null) {
-                    startActivity(Intent().apply {
-                        component = provider.settingsActivity
-                    })
-                }
-            }
+        providerViewModel.providerLiveData.observe(this) { provider ->
+            binding.providerInfo.bind(provider)
         }
         ProviderChangedReceiver.observeForVisibility(this, this)
     }

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
@@ -19,13 +19,10 @@ package com.google.android.apps.muzei
 import android.content.res.Resources
 import android.os.Bundle
 import android.text.format.DateFormat
-import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.observe
 import androidx.recyclerview.widget.MergeAdapter
 import androidx.wear.ambient.AmbientModeSupport
-import com.google.android.apps.muzei.util.filterNotNull
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
 import net.nurik.roman.muzei.BuildConfig
@@ -69,11 +66,6 @@ class MuzeiActivity : FragmentActivity(),
 
     private lateinit var binding: MuzeiActivityBinding
 
-    private val artworkViewModel: MuzeiArtworkViewModel by viewModels()
-    private val nextArtworkViewModel: MuzeiNextArtworkViewModel by viewModels()
-    private val commandViewModel: MuzeiCommandViewModel by viewModels()
-    private val providerViewModel: MuzeiProviderViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ambientController = AmbientModeSupport.attach(this)
@@ -87,10 +79,10 @@ class MuzeiActivity : FragmentActivity(),
             val inset = (FACTOR * Resources.getSystem().displayMetrics.widthPixels).toInt()
             binding.recyclerView.setPadding(inset, 0, inset, inset)
         }
-        val artworkAdapter = MuzeiArtworkAdapter()
-        val nextArtworkAdapter = MuzeiNextArtworkAdapter()
-        val commandArtworkAdapter = MuzeiCommandAdapter()
-        val providerAdapter = MuzeiProviderAdapter()
+        val artworkAdapter = MuzeiArtworkAdapter(this)
+        val nextArtworkAdapter = MuzeiNextArtworkAdapter(this)
+        val commandArtworkAdapter = MuzeiCommandAdapter(this)
+        val providerAdapter = MuzeiProviderAdapter(this)
 
         binding.recyclerView.adapter = MergeAdapter(
                 artworkAdapter,
@@ -98,22 +90,6 @@ class MuzeiActivity : FragmentActivity(),
                 commandArtworkAdapter,
                 providerAdapter)
 
-        artworkViewModel.artworkLiveData.filterNotNull().observe(this) { artwork ->
-            artworkAdapter.submitList(listOf(artwork))
-        }
-
-        nextArtworkViewModel.providerLiveData.observe(this) { provider ->
-            nextArtworkAdapter.submitList(listOfNotNull(
-                    provider?.takeIf { it.supportsNextArtwork }))
-        }
-
-        commandViewModel.commandsLiveData.observe(this) { commands ->
-            commandArtworkAdapter.submitList(commands)
-        }
-
-        providerViewModel.providerLiveData.observe(this) { provider ->
-            providerAdapter.submitList(listOf(provider))
-        }
         ProviderChangedReceiver.observeForVisibility(this, this)
     }
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiActivity.kt
@@ -59,8 +59,8 @@ class MuzeiActivity : FragmentActivity(),
                 private var showImageOnExit = false
 
                 override fun onEnterAmbient(ambientDetails: Bundle?) {
-                    showImageOnExit = binding.image.isVisible
-                    binding.image.isVisible = false
+                    showImageOnExit = binding.artworkInfo.image.isVisible
+                    binding.artworkInfo.image.isVisible = false
                     binding.time.isVisible = true
                     updateTime()
                 }
@@ -77,7 +77,7 @@ class MuzeiActivity : FragmentActivity(),
                 }
 
                 override fun onExitAmbient() {
-                    binding.image.isVisible = showImageOnExit
+                    binding.artworkInfo.image.isVisible = showImageOnExit
                     binding.time.isVisible = false
                 }
             }
@@ -100,11 +100,11 @@ class MuzeiActivity : FragmentActivity(),
             val inset = (FACTOR * Resources.getSystem().displayMetrics.widthPixels).toInt()
             binding.content.setPadding(inset, 0, inset, inset)
         }
-        binding.image.setOnClickListener {
+        binding.artworkInfo.image.setOnClickListener {
             startActivity(Intent(this@MuzeiActivity,
                     FullScreenActivity::class.java))
         }
-        binding.nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
+        binding.nextArtwork.nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
             isClipEnabled = true
             radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
             backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
@@ -113,14 +113,14 @@ class MuzeiActivity : FragmentActivity(),
                     R.drawable.ic_next_artwork)
             bounds = Rect(0, 0, radius * 2, radius * 2)
         }, null, null, null)
-        binding.nextArtwork.setOnClickListener {
+        binding.nextArtwork.nextArtwork.setOnClickListener {
             ProviderManager.getInstance(this).nextArtwork()
         }
-        binding.provider.setOnClickListener {
+        binding.providerInfo.provider.setOnClickListener {
             startActivity(Intent(this@MuzeiActivity,
                     ChooseProviderActivity::class.java))
         }
-        binding.settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
+        binding.providerInfo.settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
             isClipEnabled = true
             radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
             backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
@@ -135,22 +135,22 @@ class MuzeiActivity : FragmentActivity(),
                 val image = ImageLoader.decode(
                         contentResolver, artwork.contentUri)
                 if (image != null) {
-                    binding.image.setImageDrawable(RoundedDrawable().apply {
+                    binding.artworkInfo.image.setImageDrawable(RoundedDrawable().apply {
                         isClipEnabled = true
                         radius = resources.getDimensionPixelSize(R.dimen.art_detail_image_radius)
                         drawable = BitmapDrawable(resources, image)
                     })
                 }
-                binding.image.contentDescription = artwork.title
+                binding.artworkInfo.image.contentDescription = artwork.title
                         ?: artwork.byline
                         ?: artwork.attribution
-                binding.image.isVisible = image != null && !ambientController.isAmbient
-                binding.title.text = artwork.title
-                binding.title.isVisible = !artwork.title.isNullOrBlank()
-                binding.byline.text = artwork.byline
-                binding.byline.isVisible = !artwork.byline.isNullOrBlank()
-                binding.attribution.text = artwork.attribution
-                binding.attribution.isVisible = !artwork.attribution.isNullOrBlank()
+                binding.artworkInfo.image.isVisible = image != null && !ambientController.isAmbient
+                binding.artworkInfo.title.text = artwork.title
+                binding.artworkInfo.title.isVisible = !artwork.title.isNullOrBlank()
+                binding.artworkInfo.byline.text = artwork.byline
+                binding.artworkInfo.byline.isVisible = !artwork.byline.isNullOrBlank()
+                binding.artworkInfo.attribution.text = artwork.attribution
+                binding.artworkInfo.attribution.isVisible = !artwork.attribution.isNullOrBlank()
                 val commands = artwork.getCommands(this@MuzeiActivity)
                 // TODO Show multiple commands rather than only the first
                 val command = commands.filterNot { action ->
@@ -159,8 +159,8 @@ class MuzeiActivity : FragmentActivity(),
                     action.shouldShowIcon()
                 }
                 if (command != null) {
-                    binding.command.text = command.title
-                    binding.command.setCompoundDrawablesRelative(RoundedDrawable().apply {
+                    binding.command.command.text = command.title
+                    binding.command.command.setCompoundDrawablesRelative(RoundedDrawable().apply {
                         isClipEnabled = true
                         radius = resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
                         backgroundColor = ContextCompat.getColor(this@MuzeiActivity,
@@ -168,7 +168,7 @@ class MuzeiActivity : FragmentActivity(),
                         drawable = command.icon.loadDrawable(this@MuzeiActivity)
                         bounds = Rect(0, 0, radius * 2, radius * 2)
                     }, null, null, null)
-                    binding.command.setOnClickListener {
+                    binding.command.command.setOnClickListener {
                         Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
                             param(FirebaseAnalytics.Param.ITEM_LIST_ID, artwork.providerAuthority)
                             param(FirebaseAnalytics.Param.ITEM_NAME, command.title.toString())
@@ -177,9 +177,9 @@ class MuzeiActivity : FragmentActivity(),
                         }
                         command.actionIntent.send()
                     }
-                    binding.command.isVisible = true
+                    binding.command.command.isVisible = true
                 } else {
-                    binding.command.isVisible = false
+                    binding.command.command.isVisible = false
                 }
             }
         }
@@ -193,7 +193,7 @@ class MuzeiActivity : FragmentActivity(),
                 }
                 return@observe
             }
-            binding.nextArtwork.isVisible = provider.supportsNextArtwork
+            binding.nextArtwork.nextArtwork.isVisible = provider.supportsNextArtwork
             val pm = packageManager
             val providerInfo = pm.resolveContentProvider(provider.authority,
                     PackageManager.GET_META_DATA)
@@ -201,20 +201,20 @@ class MuzeiActivity : FragmentActivity(),
                 val size = resources.getDimensionPixelSize(R.dimen.choose_provider_image_size)
                 val icon = providerInfo.loadIcon(pm)
                 icon.bounds = Rect(0, 0, size, size)
-                binding.provider.setCompoundDrawablesRelative(icon,
+                binding.providerInfo.provider.setCompoundDrawablesRelative(icon,
                         null, null, null)
-                binding.provider.text = providerInfo.loadLabel(pm)
+                binding.providerInfo.provider.text = providerInfo.loadLabel(pm)
                 val authority = providerInfo.authority
                 lifecycleScope.launch(Dispatchers.Main) {
                     val description = ProviderManager.getDescription(this@MuzeiActivity, authority)
-                    binding.providerDescription.isGone = description.isBlank()
-                    binding.providerDescription.text = description
+                    binding.providerInfo.providerDescription.isGone = description.isBlank()
+                    binding.providerInfo.providerDescription.text = description
                 }
                 val settingsActivity = providerInfo.metaData?.getString("settingsActivity")?.run {
                     ComponentName(providerInfo.packageName, this)
                 }
-                binding.settings.isVisible = settingsActivity != null
-                binding.settings.setOnClickListener {
+                binding.providerInfo.settings.isVisible = settingsActivity != null
+                binding.providerInfo.settings.setOnClickListener {
                     if (settingsActivity != null) {
                         startActivity(Intent().apply {
                             component = settingsActivity

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
@@ -22,6 +22,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.get
+import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -71,7 +76,7 @@ class MuzeiArtworkViewHolder(
     }
 }
 
-class MuzeiArtworkAdapter : ListAdapter<Artwork, MuzeiArtworkViewHolder>(
+class MuzeiArtworkAdapter<O>(owner: O) : ListAdapter<Artwork, MuzeiArtworkViewHolder>(
         object : DiffUtil.ItemCallback<Artwork>() {
             override fun areItemsTheSame(
                     artwork1: Artwork,
@@ -83,7 +88,14 @@ class MuzeiArtworkAdapter : ListAdapter<Artwork, MuzeiArtworkViewHolder>(
                     artwork2: Artwork
             ) = artwork1 == artwork2
         }
-) {
+) where O : LifecycleOwner, O : ViewModelStoreOwner {
+    init {
+        val viewModel: MuzeiArtworkViewModel = ViewModelProvider(owner).get()
+        viewModel.artworkLiveData.observe(owner) { artwork ->
+            submitList(listOfNotNull(artwork))
+        }
+    }
+
     override fun onCreateViewHolder(
             parent: ViewGroup,
             viewType: Int

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
@@ -40,43 +40,35 @@ class MuzeiArtworkViewHolder(
         private val binding: MuzeiArtworkItemBinding
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
-        binding.create()
-    }
-
-    fun bind(artwork: Artwork) {
-        binding.bind(artwork)
-    }
-}
-
-fun MuzeiArtworkItemBinding.create() {
-    val context = root.context
-    image.setOnClickListener {
-        context.startActivity(Intent(context, FullScreenActivity::class.java))
-    }
-}
-
-fun MuzeiArtworkItemBinding.bind(artwork: Artwork) {
-    image.load(artwork.contentUri) {
-        allowHardware(false)
-        target { loadedDrawable ->
-            image.setImageDrawable(RoundedDrawable().apply {
-                isClipEnabled = true
-                radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_image_radius)
-                drawable = loadedDrawable
-            })
+        val context = binding.root.context
+        binding.image.setOnClickListener {
+            context.startActivity(Intent(context, FullScreenActivity::class.java))
         }
-        listener(
-                onError = { _, _ -> image.isVisible = false },
-                onSuccess = { _, _ -> image.isVisible = true }
-        )
     }
-    image.contentDescription = artwork.title ?: artwork.byline ?: artwork.attribution
-    title.text = artwork.title
-    title.isVisible = !artwork.title.isNullOrBlank()
-    byline.text = artwork.byline
-    byline.isVisible = !artwork.byline.isNullOrBlank()
-    attribution.text = artwork.attribution
-    attribution.isVisible = !artwork.attribution.isNullOrBlank()
+
+    fun bind(artwork: Artwork) = binding.run {
+        image.load(artwork.contentUri) {
+            allowHardware(false)
+            target { loadedDrawable ->
+                image.setImageDrawable(RoundedDrawable().apply {
+                    isClipEnabled = true
+                    radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_image_radius)
+                    drawable = loadedDrawable
+                })
+            }
+            listener(
+                    onError = { _, _ -> image.isVisible = false },
+                    onSuccess = { _, _ -> image.isVisible = true }
+            )
+        }
+        image.contentDescription = artwork.title ?: artwork.byline ?: artwork.attribution
+        title.text = artwork.title
+        title.isVisible = !artwork.title.isNullOrBlank()
+        byline.text = artwork.byline
+        byline.isVisible = !artwork.byline.isNullOrBlank()
+        attribution.text = artwork.attribution
+        attribution.isVisible = !artwork.attribution.isNullOrBlank()
+    }
 }
 
 class MuzeiArtworkAdapter : ListAdapter<Artwork, MuzeiArtworkViewHolder>(

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
@@ -18,8 +18,13 @@ package com.google.android.apps.muzei
 
 import android.app.Application
 import android.content.Intent
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.lifecycle.AndroidViewModel
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.RoundedDrawable
 import coil.api.load
 import com.google.android.apps.muzei.room.Artwork
@@ -29,6 +34,18 @@ import net.nurik.roman.muzei.databinding.MuzeiArtworkItemBinding
 
 class MuzeiArtworkViewModel(application: Application) : AndroidViewModel(application) {
     val artworkLiveData = MuzeiDatabase.getInstance(application).artworkDao().currentArtwork
+}
+
+class MuzeiArtworkViewHolder(
+        private val binding: MuzeiArtworkItemBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        binding.create()
+    }
+
+    fun bind(artwork: Artwork) {
+        binding.bind(artwork)
+    }
 }
 
 fun MuzeiArtworkItemBinding.create() {
@@ -60,4 +77,28 @@ fun MuzeiArtworkItemBinding.bind(artwork: Artwork) {
     byline.isVisible = !artwork.byline.isNullOrBlank()
     attribution.text = artwork.attribution
     attribution.isVisible = !artwork.attribution.isNullOrBlank()
+}
+
+class MuzeiArtworkAdapter : ListAdapter<Artwork, MuzeiArtworkViewHolder>(
+        object : DiffUtil.ItemCallback<Artwork>() {
+            override fun areItemsTheSame(
+                    artwork1: Artwork,
+                    artwork2: Artwork
+            ) = artwork1.id == artwork2.id
+
+            override fun areContentsTheSame(
+                    artwork1: Artwork,
+                    artwork2: Artwork
+            ) = artwork1 == artwork2
+        }
+) {
+    override fun onCreateViewHolder(
+            parent: ViewGroup,
+            viewType: Int
+    ) = MuzeiArtworkViewHolder(MuzeiArtworkItemBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false))
+
+    override fun onBindViewHolder(holder: MuzeiArtworkViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
 }

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiArtworkItem.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei
+
+import android.app.Application
+import android.content.Intent
+import androidx.core.view.isVisible
+import androidx.lifecycle.AndroidViewModel
+import androidx.wear.widget.RoundedDrawable
+import coil.api.load
+import com.google.android.apps.muzei.room.Artwork
+import com.google.android.apps.muzei.room.MuzeiDatabase
+import net.nurik.roman.muzei.R
+import net.nurik.roman.muzei.databinding.MuzeiArtworkItemBinding
+
+class MuzeiArtworkViewModel(application: Application) : AndroidViewModel(application) {
+    val artworkLiveData = MuzeiDatabase.getInstance(application).artworkDao().currentArtwork
+}
+
+fun MuzeiArtworkItemBinding.create() {
+    val context = root.context
+    image.setOnClickListener {
+        context.startActivity(Intent(context, FullScreenActivity::class.java))
+    }
+}
+
+fun MuzeiArtworkItemBinding.bind(artwork: Artwork) {
+    image.load(artwork.contentUri) {
+        allowHardware(false)
+        target { loadedDrawable ->
+            image.setImageDrawable(RoundedDrawable().apply {
+                isClipEnabled = true
+                radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_image_radius)
+                drawable = loadedDrawable
+            })
+        }
+        listener(
+                onError = { _, _ -> image.isVisible = false },
+                onSuccess = { _, _ -> image.isVisible = true }
+        )
+    }
+    image.contentDescription = artwork.title ?: artwork.byline ?: artwork.attribution
+    title.text = artwork.title
+    title.isVisible = !artwork.title.isNullOrBlank()
+    byline.text = artwork.byline
+    byline.isVisible = !artwork.byline.isNullOrBlank()
+    attribution.text = artwork.attribution
+    attribution.isVisible = !artwork.attribution.isNullOrBlank()
+}

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -47,14 +47,15 @@ data class ArtworkCommand(
     val title = command.title
     val actionIntent = command.actionIntent
     val icon = command.icon
-    fun shouldShowIcon() = command.shouldShowIcon()
 }
 
 class MuzeiCommandViewModel(application: Application) : AndroidViewModel(application) {
     val commandsLiveData = MuzeiDatabase.getInstance(application).artworkDao().currentArtwork.switchMap { artwork ->
         liveData {
             if (artwork != null) {
-                emit(artwork.getCommands(getApplication<Application>()).map { command ->
+                emit(artwork.getCommands(getApplication<Application>()).sortedByDescending { command ->
+                    command.shouldShowIcon()
+                }.map { command ->
                     ArtworkCommand(artwork, command)
                 })
             } else {

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -18,11 +18,16 @@ package com.google.android.apps.muzei
 
 import android.app.Application
 import android.graphics.Rect
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.core.app.RemoteActionCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.liveData
 import androidx.lifecycle.switchMap
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.RoundedDrawable
 import com.google.android.apps.muzei.room.Artwork
 import com.google.android.apps.muzei.room.MuzeiDatabase
@@ -59,6 +64,15 @@ class MuzeiCommandViewModel(application: Application) : AndroidViewModel(applica
     }
 }
 
+class MuzeiCommandViewHolder(
+        private val binding: MuzeiCommandItemBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(artworkCommand: ArtworkCommand) {
+        binding.bind(artworkCommand)
+    }
+}
+
 fun MuzeiCommandItemBinding.bind(artworkCommand: ArtworkCommand) {
     val context = root.context
     command.text = artworkCommand.title
@@ -77,5 +91,29 @@ fun MuzeiCommandItemBinding.bind(artworkCommand: ArtworkCommand) {
             param(FirebaseAnalytics.Param.CONTENT_TYPE, "wear_activity")
         }
         artworkCommand.actionIntent.send()
+    }
+}
+
+class MuzeiCommandAdapter : ListAdapter<ArtworkCommand, MuzeiCommandViewHolder>(
+        object : DiffUtil.ItemCallback<ArtworkCommand>() {
+            override fun areItemsTheSame(
+                    artworkCommand1: ArtworkCommand,
+                    artworkCommand2: ArtworkCommand
+            ) = artworkCommand1.title == artworkCommand2.title
+
+            override fun areContentsTheSame(
+                    artworkCommand1: ArtworkCommand,
+                    artworkCommand2: ArtworkCommand
+            ) = artworkCommand1 == artworkCommand2
+        }
+) {
+    override fun onCreateViewHolder(
+            parent: ViewGroup,
+            viewType: Int
+    ) = MuzeiCommandViewHolder(MuzeiCommandItemBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false))
+
+    override fun onBindViewHolder(holder: MuzeiCommandViewHolder, position: Int) {
+        holder.bind(getItem(position))
     }
 }

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -23,7 +23,12 @@ import android.view.ViewGroup
 import androidx.core.app.RemoteActionCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.get
 import androidx.lifecycle.liveData
+import androidx.lifecycle.observe
 import androidx.lifecycle.switchMap
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -91,7 +96,7 @@ class MuzeiCommandViewHolder(
     }
 }
 
-class MuzeiCommandAdapter : ListAdapter<ArtworkCommand, MuzeiCommandViewHolder>(
+class MuzeiCommandAdapter<O>(owner: O) : ListAdapter<ArtworkCommand, MuzeiCommandViewHolder>(
         object : DiffUtil.ItemCallback<ArtworkCommand>() {
             override fun areItemsTheSame(
                     artworkCommand1: ArtworkCommand,
@@ -103,7 +108,14 @@ class MuzeiCommandAdapter : ListAdapter<ArtworkCommand, MuzeiCommandViewHolder>(
                     artworkCommand2: ArtworkCommand
             ) = artworkCommand1 == artworkCommand2
         }
-) {
+) where O : LifecycleOwner, O : ViewModelStoreOwner {
+    init {
+        val viewModel: MuzeiCommandViewModel = ViewModelProvider(owner).get()
+        viewModel.commandsLiveData.observe(owner) { commands ->
+            submitList(commands)
+        }
+    }
+
     override fun onCreateViewHolder(
             parent: ViewGroup,
             viewType: Int

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -78,7 +78,6 @@ class MuzeiCommandViewHolder(
         val context = root.context
         command.text = artworkCommand.title
         command.setCompoundDrawablesRelative(RoundedDrawable().apply {
-            isClipEnabled = true
             radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
             backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
             drawable = artworkCommand.icon.loadDrawable(context)

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -68,29 +68,25 @@ class MuzeiCommandViewHolder(
         private val binding: MuzeiCommandItemBinding
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(artworkCommand: ArtworkCommand) {
-        binding.bind(artworkCommand)
-    }
-}
-
-fun MuzeiCommandItemBinding.bind(artworkCommand: ArtworkCommand) {
-    val context = root.context
-    command.text = artworkCommand.title
-    command.setCompoundDrawablesRelative(RoundedDrawable().apply {
-        isClipEnabled = true
-        radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
-        drawable = artworkCommand.icon.loadDrawable(context)
-        bounds = Rect(0, 0, radius * 2, radius * 2)
-    }, null, null, null)
-    command.setOnClickListener {
-        Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
-            param(FirebaseAnalytics.Param.ITEM_LIST_ID, artworkCommand.providerAuthority)
-            param(FirebaseAnalytics.Param.ITEM_NAME, artworkCommand.title.toString())
-            param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "actions")
-            param(FirebaseAnalytics.Param.CONTENT_TYPE, "wear_activity")
+    fun bind(artworkCommand: ArtworkCommand) = binding.run {
+        val context = root.context
+        command.text = artworkCommand.title
+        command.setCompoundDrawablesRelative(RoundedDrawable().apply {
+            isClipEnabled = true
+            radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+            backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+            drawable = artworkCommand.icon.loadDrawable(context)
+            bounds = Rect(0, 0, radius * 2, radius * 2)
+        }, null, null, null)
+        command.setOnClickListener {
+            Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
+                param(FirebaseAnalytics.Param.ITEM_LIST_ID, artworkCommand.providerAuthority)
+                param(FirebaseAnalytics.Param.ITEM_NAME, artworkCommand.title.toString())
+                param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "actions")
+                param(FirebaseAnalytics.Param.CONTENT_TYPE, "wear_activity")
+            }
+            artworkCommand.actionIntent.send()
         }
-        artworkCommand.actionIntent.send()
     }
 }
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiCommandItem.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei
+
+import android.app.Application
+import android.graphics.Rect
+import androidx.core.app.RemoteActionCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.liveData
+import androidx.lifecycle.switchMap
+import androidx.wear.widget.RoundedDrawable
+import com.google.android.apps.muzei.room.Artwork
+import com.google.android.apps.muzei.room.MuzeiDatabase
+import com.google.android.apps.muzei.room.getCommands
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.ktx.Firebase
+import net.nurik.roman.muzei.R
+import net.nurik.roman.muzei.databinding.MuzeiCommandItemBinding
+
+data class ArtworkCommand(
+        private val artwork: Artwork,
+        private val command: RemoteActionCompat
+) {
+    val providerAuthority = artwork.providerAuthority
+    val title = command.title
+    val actionIntent = command.actionIntent
+    val icon = command.icon
+    fun shouldShowIcon() = command.shouldShowIcon()
+}
+
+class MuzeiCommandViewModel(application: Application) : AndroidViewModel(application) {
+    val commandsLiveData = MuzeiDatabase.getInstance(application).artworkDao().currentArtwork.switchMap { artwork ->
+        liveData {
+            if (artwork != null) {
+                emit(artwork.getCommands(getApplication<Application>()).map { command ->
+                    ArtworkCommand(artwork, command)
+                })
+            } else {
+                emit(emptyList<ArtworkCommand>())
+            }
+        }
+    }
+}
+
+fun MuzeiCommandItemBinding.bind(artworkCommand: ArtworkCommand) {
+    val context = root.context
+    command.text = artworkCommand.title
+    command.setCompoundDrawablesRelative(RoundedDrawable().apply {
+        isClipEnabled = true
+        radius = root.context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+        drawable = artworkCommand.icon.loadDrawable(context)
+        bounds = Rect(0, 0, radius * 2, radius * 2)
+    }, null, null, null)
+    command.setOnClickListener {
+        Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
+            param(FirebaseAnalytics.Param.ITEM_LIST_ID, artworkCommand.providerAuthority)
+            param(FirebaseAnalytics.Param.ITEM_NAME, artworkCommand.title.toString())
+            param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "actions")
+            param(FirebaseAnalytics.Param.CONTENT_TYPE, "wear_activity")
+        }
+        artworkCommand.actionIntent.send()
+    }
+}

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
@@ -22,6 +22,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.get
+import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -55,7 +60,7 @@ class MuzeiNextArtworkViewHolder(
     }
 }
 
-class MuzeiNextArtworkAdapter : ListAdapter<Provider, MuzeiNextArtworkViewHolder>(
+class MuzeiNextArtworkAdapter<O>(owner: O) : ListAdapter<Provider, MuzeiNextArtworkViewHolder>(
         object : DiffUtil.ItemCallback<Provider>() {
             override fun areItemsTheSame(
                     provider1: Provider,
@@ -67,7 +72,14 @@ class MuzeiNextArtworkAdapter : ListAdapter<Provider, MuzeiNextArtworkViewHolder
                     provider2: Provider
             ) = provider1 == provider2
         }
-) {
+) where O : LifecycleOwner, O : ViewModelStoreOwner {
+    init {
+        val viewModel: MuzeiNextArtworkViewModel = ViewModelProvider(owner).get()
+        viewModel.providerLiveData.observe(owner) { provider ->
+            submitList(listOfNotNull(provider?.takeIf { it.supportsNextArtwork }))
+        }
+    }
+
     override fun onCreateViewHolder(
             parent: ViewGroup,
             viewType: Int

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
@@ -39,21 +39,19 @@ class MuzeiNextArtworkViewHolder(
         binding: MuzeiNextArtworkItemBinding
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
-        binding.create()
-    }
-}
-
-fun MuzeiNextArtworkItemBinding.create() {
-    val context = root.context
-    nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
-        isClipEnabled = true
-        radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
-        drawable = ContextCompat.getDrawable(context, R.drawable.ic_next_artwork)
-        bounds = Rect(0, 0, radius * 2, radius * 2)
-    }, null, null, null)
-    nextArtwork.setOnClickListener {
-        ProviderManager.getInstance(context).nextArtwork()
+        binding.run {
+            val context = root.context
+            nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
+                isClipEnabled = true
+                radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+                backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+                drawable = ContextCompat.getDrawable(context, R.drawable.ic_next_artwork)
+                bounds = Rect(0, 0, radius * 2, radius * 2)
+            }, null, null, null)
+            nextArtwork.setOnClickListener {
+                ProviderManager.getInstance(context).nextArtwork()
+            }
+        }
     }
 }
 

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei
+
+import android.app.Application
+import android.graphics.Rect
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.AndroidViewModel
+import androidx.wear.widget.RoundedDrawable
+import com.google.android.apps.muzei.sync.ProviderManager
+import net.nurik.roman.muzei.R
+import net.nurik.roman.muzei.databinding.MuzeiNextArtworkItemBinding
+
+class MuzeiNextArtworkViewModel(application: Application) : AndroidViewModel(application) {
+    val providerLiveData = ProviderManager.getInstance(getApplication())
+}
+
+fun MuzeiNextArtworkItemBinding.create() {
+    val context = root.context
+    nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
+        isClipEnabled = true
+        radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+        drawable = ContextCompat.getDrawable(context, R.drawable.ic_next_artwork)
+        bounds = Rect(0, 0, radius * 2, radius * 2)
+    }, null, null, null)
+    nextArtwork.setOnClickListener {
+        ProviderManager.getInstance(context).nextArtwork()
+    }
+}

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
@@ -18,15 +18,29 @@ package com.google.android.apps.muzei
 
 import android.app.Application
 import android.graphics.Rect
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.RoundedDrawable
+import com.google.android.apps.muzei.room.Provider
 import com.google.android.apps.muzei.sync.ProviderManager
 import net.nurik.roman.muzei.R
 import net.nurik.roman.muzei.databinding.MuzeiNextArtworkItemBinding
 
 class MuzeiNextArtworkViewModel(application: Application) : AndroidViewModel(application) {
     val providerLiveData = ProviderManager.getInstance(getApplication())
+}
+
+class MuzeiNextArtworkViewHolder(
+        binding: MuzeiNextArtworkItemBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        binding.create()
+    }
 }
 
 fun MuzeiNextArtworkItemBinding.create() {
@@ -40,5 +54,28 @@ fun MuzeiNextArtworkItemBinding.create() {
     }, null, null, null)
     nextArtwork.setOnClickListener {
         ProviderManager.getInstance(context).nextArtwork()
+    }
+}
+
+class MuzeiNextArtworkAdapter : ListAdapter<Provider, MuzeiNextArtworkViewHolder>(
+        object : DiffUtil.ItemCallback<Provider>() {
+            override fun areItemsTheSame(
+                    provider1: Provider,
+                    provider2: Provider
+            ) = provider1.authority == provider2.authority
+
+            override fun areContentsTheSame(
+                    provider1: Provider,
+                    provider2: Provider
+            ) = provider1 == provider2
+        }
+) {
+    override fun onCreateViewHolder(
+            parent: ViewGroup,
+            viewType: Int
+    ) = MuzeiNextArtworkViewHolder(MuzeiNextArtworkItemBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false))
+
+    override fun onBindViewHolder(holder: MuzeiNextArtworkViewHolder, position: Int) {
     }
 }

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiNextArtworkItem.kt
@@ -47,7 +47,6 @@ class MuzeiNextArtworkViewHolder(
         binding.run {
             val context = root.context
             nextArtwork.setCompoundDrawablesRelative(RoundedDrawable().apply {
-                isClipEnabled = true
                 radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
                 backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
                 drawable = ContextCompat.getDrawable(context, R.drawable.ic_next_artwork)

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
@@ -28,7 +28,12 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.get
 import androidx.lifecycle.liveData
+import androidx.lifecycle.observe
 import androidx.lifecycle.switchMap
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -117,7 +122,7 @@ class MuzeiProviderViewHolder(
     }
 }
 
-class MuzeiProviderAdapter : ListAdapter<ProviderData, MuzeiProviderViewHolder>(
+class MuzeiProviderAdapter<O>(owner: O) : ListAdapter<ProviderData, MuzeiProviderViewHolder>(
         object : DiffUtil.ItemCallback<ProviderData>() {
             override fun areItemsTheSame(
                     providerData1: ProviderData,
@@ -129,7 +134,13 @@ class MuzeiProviderAdapter : ListAdapter<ProviderData, MuzeiProviderViewHolder>(
                     providerData2: ProviderData
             ) = providerData1.provider == providerData2.provider
         }
-) {
+) where O : LifecycleOwner, O : ViewModelStoreOwner {
+    init {
+        val viewModel: MuzeiProviderViewModel = ViewModelProvider(owner).get()
+        viewModel.providerLiveData.observe(owner) { provider ->
+            submitList(listOf(provider))
+        }
+    }
 
     override fun onCreateViewHolder(
             parent: ViewGroup,

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei
+
+import android.app.Application
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.liveData
+import androidx.lifecycle.switchMap
+import androidx.wear.widget.RoundedDrawable
+import com.google.android.apps.muzei.datalayer.ActivateMuzeiIntentService
+import com.google.android.apps.muzei.featuredart.BuildConfig
+import com.google.android.apps.muzei.sync.ProviderManager
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import net.nurik.roman.muzei.R
+import net.nurik.roman.muzei.databinding.MuzeiProviderItemBinding
+
+data class ProviderData(
+        val icon: Drawable,
+        val label: CharSequence,
+        val description: String,
+        val settingsActivity: ComponentName?
+)
+
+class MuzeiProviderViewModel(application: Application) : AndroidViewModel(application) {
+    val providerLiveData = ProviderManager.getInstance(getApplication()).switchMap { provider ->
+        liveData {
+            val app = getApplication<Application>()
+            if (provider != null) {
+                val pm = app.packageManager
+                val providerInfo = pm.resolveContentProvider(provider.authority,
+                        PackageManager.GET_META_DATA)
+                if (providerInfo != null) {
+                    val icon = providerInfo.loadIcon(pm)
+                    val label = providerInfo.loadLabel(pm)
+                    val settingsActivity = providerInfo.metaData?.getString("settingsActivity")?.run {
+                        ComponentName(providerInfo.packageName, this)
+                    }
+                    emit(ProviderData(icon, label,
+                            ProviderManager.getDescription(app, provider.authority),
+                            settingsActivity))
+                }
+            } else {
+                GlobalScope.launch {
+                    ProviderManager.select(app, BuildConfig.FEATURED_ART_AUTHORITY)
+                    ActivateMuzeiIntentService.checkForPhoneApp(app)
+                }
+            }
+        }
+    }
+}
+
+fun MuzeiProviderItemBinding.create() {
+    val context = root.context
+    provider.setOnClickListener {
+        context.startActivity(Intent(context, ChooseProviderActivity::class.java))
+    }
+    settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
+        isClipEnabled = true
+        radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+        drawable = ContextCompat.getDrawable(context, R.drawable.ic_provider_settings)
+        bounds = Rect(0, 0, radius * 2, radius * 2)
+    }, null, null, null)
+}
+
+fun MuzeiProviderItemBinding.bind(providerData: ProviderData) {
+    val context = root.context
+    val size = context.resources.getDimensionPixelSize(R.dimen.choose_provider_image_size)
+    providerData.icon.bounds = Rect(0, 0, size, size)
+    provider.setCompoundDrawablesRelative(providerData.icon,
+            null, null, null)
+    provider.text = providerData.label
+    providerDescription.isGone = providerData.description.isBlank()
+    providerDescription.text = providerData.description
+    settings.isVisible = providerData.settingsActivity != null
+    settings.setOnClickListener {
+        if (providerData.settingsActivity != null) {
+            context.startActivity(Intent().apply {
+                component = providerData.settingsActivity
+            })
+        }
+    }
+}

--- a/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
+++ b/wearable/src/main/java/com/google/android/apps/muzei/MuzeiProviderItem.kt
@@ -82,44 +82,37 @@ class MuzeiProviderViewModel(application: Application) : AndroidViewModel(applic
 class MuzeiProviderViewHolder(
         private val binding: MuzeiProviderItemBinding
 ) : RecyclerView.ViewHolder(binding.root) {
+    private val context = binding.root.context
+
     init {
-        binding.create()
+        binding.provider.setOnClickListener {
+            context.startActivity(Intent(context, ChooseProviderActivity::class.java))
+        }
+        binding.settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
+            isClipEnabled = true
+            radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
+            backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
+            drawable = ContextCompat.getDrawable(context, R.drawable.ic_provider_settings)
+            bounds = Rect(0, 0, radius * 2, radius * 2)
+        }, null, null, null)
     }
 
-    fun bind(providerData: ProviderData) {
-        binding.bind(providerData)
-    }
-}
-
-fun MuzeiProviderItemBinding.create() {
-    val context = root.context
-    provider.setOnClickListener {
-        context.startActivity(Intent(context, ChooseProviderActivity::class.java))
-    }
-    settings.setCompoundDrawablesRelative(RoundedDrawable().apply {
-        isClipEnabled = true
-        radius = context.resources.getDimensionPixelSize(R.dimen.art_detail_open_on_phone_radius)
-        backgroundColor = ContextCompat.getColor(context, R.color.theme_primary)
-        drawable = ContextCompat.getDrawable(context, R.drawable.ic_provider_settings)
-        bounds = Rect(0, 0, radius * 2, radius * 2)
-    }, null, null, null)
-}
-
-fun MuzeiProviderItemBinding.bind(providerData: ProviderData) {
-    val context = root.context
-    val size = context.resources.getDimensionPixelSize(R.dimen.choose_provider_image_size)
-    providerData.icon.bounds = Rect(0, 0, size, size)
-    provider.setCompoundDrawablesRelative(providerData.icon,
-            null, null, null)
-    provider.text = providerData.label
-    providerDescription.isGone = providerData.description.isBlank()
-    providerDescription.text = providerData.description
-    settings.isVisible = providerData.settingsActivity != null
-    settings.setOnClickListener {
-        if (providerData.settingsActivity != null) {
-            context.startActivity(Intent().apply {
-                component = providerData.settingsActivity
-            })
+    fun bind(providerData: ProviderData) = binding.run {
+        val context = root.context
+        val size = context.resources.getDimensionPixelSize(R.dimen.choose_provider_image_size)
+        providerData.icon.bounds = Rect(0, 0, size, size)
+        provider.setCompoundDrawablesRelative(providerData.icon,
+                null, null, null)
+        provider.text = providerData.label
+        providerDescription.isGone = providerData.description.isBlank()
+        providerDescription.text = providerData.description
+        settings.isVisible = providerData.settingsActivity != null
+        settings.setOnClickListener {
+            if (providerData.settingsActivity != null) {
+                context.startActivity(Intent().apply {
+                    component = providerData.settingsActivity
+                })
+            }
         }
     }
 }

--- a/wearable/src/main/res/layout/muzei_activity.xml
+++ b/wearable/src/main/res/layout/muzei_activity.xml
@@ -16,42 +16,19 @@
 
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView
-        android:id="@+id/scroll_view"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <LinearLayout
-            android:id="@+id/content"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingBottom="8dp"
-            android:paddingEnd="8dp"
-            android:paddingStart="8dp">
-
-            <include
-                android:id="@+id/artwork_info"
-                layout="@layout/muzei_artwork_item" />
-
-            <include
-                android:id="@+id/next_artwork"
-                layout="@layout/muzei_next_artwork_item"
-                android:visibility="gone" />
-
-            <include
-                android:id="@+id/command"
-                layout="@layout/muzei_command_item"
-                android:visibility="gone" />
-
-            <include
-                android:id="@+id/provider_info"
-                layout="@layout/muzei_provider_item" />
-        </LinearLayout>
-    </ScrollView>
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="8dp"
+        app:layoutManager="LinearLayoutManager" />
 
     <TextView
         android:id="@+id/time"
@@ -62,5 +39,5 @@
         android:fontFamily="@font/nunito_clock_regular"
         android:gravity="center"
         android:textSize="@dimen/clock_text_size"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 </FrameLayout>

--- a/wearable/src/main/res/layout/muzei_activity.xml
+++ b/wearable/src/main/res/layout/muzei_activity.xml
@@ -14,47 +14,53 @@
   limitations under the License.
   -->
 
-<ScrollView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/content"
+    <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="8dp"
-        android:paddingEnd="8dp"
-        android:paddingStart="8dp">
+        android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/time"
+        <LinearLayout
+            android:id="@+id/content"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/art_detail_image_size"
-            android:layout_marginTop="8dp"
-            android:fontFamily="@font/nunito_clock_regular"
-            android:gravity="center"
-            android:textSize="@dimen/clock_text_size"
-            android:visibility="gone"/>
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="8dp"
+            android:paddingEnd="8dp"
+            android:paddingStart="8dp">
 
-        <include
-            android:id="@+id/artwork_info"
-            layout="@layout/muzei_artwork_item" />
+            <include
+                android:id="@+id/artwork_info"
+                layout="@layout/muzei_artwork_item" />
 
-        <include
-            android:id="@+id/next_artwork"
-            layout="@layout/muzei_next_artwork_item"
-            android:visibility="gone" />
+            <include
+                android:id="@+id/next_artwork"
+                layout="@layout/muzei_next_artwork_item"
+                android:visibility="gone" />
 
-        <include
-            android:id="@+id/command"
-            layout="@layout/muzei_command_item"
-            android:visibility="gone" />
+            <include
+                android:id="@+id/command"
+                layout="@layout/muzei_command_item"
+                android:visibility="gone" />
 
-        <include
-            android:id="@+id/provider_info"
-            layout="@layout/muzei_provider_item" />
-    </LinearLayout>
-</ScrollView>
+            <include
+                android:id="@+id/provider_info"
+                layout="@layout/muzei_provider_item" />
+        </LinearLayout>
+    </ScrollView>
+
+    <TextView
+        android:id="@+id/time"
+        android:background="@color/black"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/art_detail_time_height"
+        android:paddingTop="8dp"
+        android:fontFamily="@font/nunito_clock_regular"
+        android:gravity="center"
+        android:textSize="@dimen/clock_text_size"
+        android:visibility="gone"/>
+</FrameLayout>

--- a/wearable/src/main/res/layout/muzei_activity.xml
+++ b/wearable/src/main/res/layout/muzei_activity.xml
@@ -16,7 +16,6 @@
 
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -40,100 +39,22 @@
             android:textSize="@dimen/clock_text_size"
             android:visibility="gone"/>
 
-        <ImageView
-            android:id="@+id/image"
-            android:layout_width="@dimen/art_detail_image_size"
-            android:layout_height="@dimen/art_detail_image_size"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="8dp"
-            tools:ignore="ContentDescription"/>
+        <include
+            android:id="@+id/artwork_info"
+            layout="@layout/muzei_artwork_item" />
 
-        <TextView
-            android:id="@+id/title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/alegreya"
-            android:paddingTop="8dp"
-            android:textSize="@dimen/art_detail_title_text_size"
-            android:textStyle="bold|italic"/>
-
-        <TextView
-            android:id="@+id/byline"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/alegreya"
-            android:paddingTop="8dp"
-            android:textSize="@dimen/art_detail_byline_text_size"
-            android:textStyle="italic"/>
-
-        <TextView
-            android:id="@+id/attribution"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/alegreya"
-            android:paddingTop="8dp"
-            android:textSize="@dimen/art_detail_attribution_text_size"
-            android:textStyle="italic"/>
-
-        <Button
+        <include
             android:id="@+id/next_artwork"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:background="?android:selectableItemBackground"
-            android:drawablePadding="8dp"
-            android:gravity="center_vertical"
-            android:text="@string/next_artwork"
-            android:textAllCaps="false"
-            android:visibility="gone"/>
+            layout="@layout/muzei_next_artwork_item"
+            android:visibility="gone" />
 
-        <Button
+        <include
             android:id="@+id/command"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:background="?android:selectableItemBackground"
-            android:drawablePadding="8dp"
-            android:gravity="center_vertical"
-            android:textAllCaps="false"
-            android:visibility="gone"/>
+            layout="@layout/muzei_command_item"
+            android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/current_provider"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingTop="8dp"
-            android:text="@string/provider_title"
-            android:textAppearance="@android:style/TextAppearance.Material.Title"
-            android:textColor="@color/theme_primary"/>
-
-        <Button
-            android:id="@+id/provider"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackground"
-            android:drawablePadding="8dp"
-            android:gravity="center_vertical"
-            android:paddingBottom="8dp"
-            android:paddingTop="8dp"
-            android:textAllCaps="false"
-            android:textSize="20sp"/>
-
-        <TextView
-            android:id="@+id/provider_description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="8dp"/>
-
-        <Button
-            android:id="@+id/settings"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:background="?android:selectableItemBackground"
-            android:text="@string/provider_settings"
-            android:textAllCaps="false"
-            android:visibility="gone"/>
+        <include
+            android:id="@+id/provider_info"
+            layout="@layout/muzei_provider_item" />
     </LinearLayout>
 </ScrollView>

--- a/wearable/src/main/res/layout/muzei_artwork_item.xml
+++ b/wearable/src/main/res/layout/muzei_artwork_item.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <ImageView

--- a/wearable/src/main/res/layout/muzei_artwork_item.xml
+++ b/wearable/src/main/res/layout/muzei_artwork_item.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="@dimen/art_detail_image_size"
+        android:layout_height="@dimen/art_detail_image_size"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        tools:ignore="ContentDescription" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/alegreya"
+        android:paddingTop="8dp"
+        android:textSize="@dimen/art_detail_title_text_size"
+        android:textStyle="bold|italic" />
+
+    <TextView
+        android:id="@+id/byline"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/alegreya"
+        android:paddingTop="8dp"
+        android:textSize="@dimen/art_detail_byline_text_size"
+        android:textStyle="italic" />
+
+    <TextView
+        android:id="@+id/attribution"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/alegreya"
+        android:paddingTop="8dp"
+        android:textSize="@dimen/art_detail_attribution_text_size"
+        android:textStyle="italic" />
+</LinearLayout>

--- a/wearable/src/main/res/layout/muzei_command_item.xml
+++ b/wearable/src/main/res/layout/muzei_command_item.xml
@@ -1,0 +1,26 @@
+<!--
+  Copyright 2020 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<Button
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/command"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:background="?android:selectableItemBackground"
+    android:drawablePadding="8dp"
+    android:gravity="center_vertical"
+    android:textAllCaps="false" />

--- a/wearable/src/main/res/layout/muzei_next_artwork_item.xml
+++ b/wearable/src/main/res/layout/muzei_next_artwork_item.xml
@@ -1,0 +1,27 @@
+<!--
+  Copyright 2020 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<Button
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/next_artwork"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:background="?android:selectableItemBackground"
+    android:drawablePadding="8dp"
+    android:gravity="center_vertical"
+    android:text="@string/next_artwork"
+    android:textAllCaps="false" />

--- a/wearable/src/main/res/layout/muzei_provider_item.xml
+++ b/wearable/src/main/res/layout/muzei_provider_item.xml
@@ -17,7 +17,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <TextView
@@ -55,6 +55,5 @@
         android:layout_marginTop="8dp"
         android:background="?android:selectableItemBackground"
         android:text="@string/provider_settings"
-        android:textAllCaps="false"
-        android:visibility="gone" />
+        android:textAllCaps="false" />
 </LinearLayout>

--- a/wearable/src/main/res/layout/muzei_provider_item.xml
+++ b/wearable/src/main/res/layout/muzei_provider_item.xml
@@ -1,0 +1,60 @@
+<!--
+  Copyright 2020 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/current_provider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="8dp"
+        android:text="@string/provider_title"
+        android:textAppearance="@android:style/TextAppearance.Material.Title"
+        android:textColor="@color/theme_primary" />
+
+    <Button
+        android:id="@+id/provider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:selectableItemBackground"
+        android:drawablePadding="8dp"
+        android:gravity="center_vertical"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:textAllCaps="false"
+        android:textSize="20sp" />
+
+    <TextView
+        android:id="@+id/provider_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp" />
+
+    <Button
+        android:id="@+id/settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="?android:selectableItemBackground"
+        android:text="@string/provider_settings"
+        android:textAllCaps="false"
+        android:visibility="gone" />
+</LinearLayout>

--- a/wearable/src/main/res/values/dimens.xml
+++ b/wearable/src/main/res/values/dimens.xml
@@ -21,6 +21,8 @@
     <dimen name="date_text_size">18sp</dimen>
     <dimen name="date_min_available_margin">32dp</dimen>
 
+    <dimen name="art_detail_time_height">72dp</dimen>
+
     <dimen name="art_detail_image_size">64dp</dimen>
     <dimen name="art_detail_image_radius">32dp</dimen>
 


### PR DESCRIPTION
Rather than only showing a single command for local sources installed on Wear OS devices, show all commands, sorting the ones with `shouldShowAsIcon()` above other commands.

As part of this, restructured the content of `MuzeiActivity` into four separate `RecyclerView.Adapter` instances:
- Artwork
- Next Artwork
- Commands
- Provider

And use `MergeAdapter` to bring all of them together into one `RecyclerView`.