### PR TITLE
Don't use negative margins for title and attribution

### DIFF
--- a/main/src/main/res/layout/art_detail_fragment.xml
+++ b/main/src/main/res/layout/art_detail_fragment.xml
@@ -17,6 +17,7 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -97,9 +98,9 @@
                     app:shadowRadius="3dp"
                     android:fontFamily="sans-serif-condensed"
                     android:paddingStart="@dimen/art_detail_metadata_margin"
-                    android:layout_marginBottom="@dimen/art_detail_attribution_title_margin"
                     android:paddingTop="@dimen/art_detail_metadata_margin"
-                    android:paddingEnd="@dimen/art_detail_metadata_margin"/>
+                    android:paddingEnd="@dimen/art_detail_metadata_margin"
+                    tools:text="Attribution"/>
 
                 <com.google.android.apps.muzei.util.ShadowDipsTextView
                     android:id="@+id/title"
@@ -110,11 +111,10 @@
                     app:shadowDx="0dp"
                     app:shadowDy="1dp"
                     app:shadowRadius="3dp"
-                    android:paddingBottom="@dimen/art_detail_title_bottom_padding"
-                    android:layout_marginBottom="@dimen/art_detail_title_byline_margin"
-                    android:paddingTop="@dimen/art_detail_metadata_margin"
                     android:paddingStart="@dimen/art_detail_metadata_margin"
-                    android:paddingEnd="@dimen/art_detail_metadata_margin"/>
+                    android:paddingTop="@dimen/art_detail_metadata_margin_top"
+                    android:paddingEnd="@dimen/art_detail_metadata_margin"
+                    tools:text="Title"/>
 
                 <com.google.android.apps.muzei.util.ShadowDipsTextView
                     android:id="@+id/byline"
@@ -126,8 +126,13 @@
                     app:shadowDy="1dp"
                     app:shadowRadius="3dp"
                     android:paddingStart="@dimen/art_detail_metadata_margin"
-                    android:paddingBottom="@dimen/art_detail_metadata_margin_bottom"
-                    android:paddingEnd="@dimen/art_detail_metadata_margin"/>
+                    android:paddingTop="@dimen/art_detail_metadata_margin_top"
+                    android:paddingEnd="@dimen/art_detail_metadata_margin"
+                    tools:text="Byline"/>
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/art_detail_metadata_margin_bottom"/>
 
             </LinearLayout>
         </FrameLayout>

--- a/main/src/main/res/values-sw600dp/dimens.xml
+++ b/main/src/main/res/values-sw600dp/dimens.xml
@@ -18,12 +18,10 @@
     <dimen name="art_detail_button_width">64dp</dimen>
     <dimen name="art_detail_button_height">96dp</dimen>
     <dimen name="art_detail_metadata_margin">32dp</dimen>
+    <dimen name="art_detail_metadata_margin_top">8dp</dimen>
     <dimen name="art_detail_metadata_margin_bottom">40dp</dimen>
     <dimen name="art_detail_title_text_size">34sp</dimen>
-    <dimen name="art_detail_title_bottom_padding">16sp</dimen>
-    <dimen name="art_detail_title_byline_margin">-8sp</dimen>
     <dimen name="art_detail_byline_text_size">26sp</dimen>
-    <dimen name="art_detail_attribution_title_margin">-16sp</dimen>
     <dimen name="art_detail_attribution_text_size">16sp</dimen>
 
     <dimen name="intro_activate_button_size">140dp</dimen>

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -18,12 +18,10 @@
     <dimen name="art_detail_button_width">56dp</dimen>
     <dimen name="art_detail_button_height">72dp</dimen>
     <dimen name="art_detail_metadata_margin">16dp</dimen>
+    <dimen name="art_detail_metadata_margin_top">0dp</dimen>
     <dimen name="art_detail_metadata_margin_bottom">20dp</dimen>
     <dimen name="art_detail_title_text_size">28sp</dimen>
-    <dimen name="art_detail_title_bottom_padding">16sp</dimen>
-    <dimen name="art_detail_title_byline_margin">-16sp</dimen>
     <dimen name="art_detail_byline_text_size">22sp</dimen>
-    <dimen name="art_detail_attribution_title_margin">-12sp</dimen>
     <dimen name="art_detail_attribution_text_size">14sp</dimen>
 
     <dimen name="intro_activate_button_size">100dp</dimen>


### PR DESCRIPTION
Simplify the attribution, title, and byline margins to better support all combinations of attribution, title, and byline. Specifically, fixing cases where only the title is empty or where everything but the attribution is empty.

Fixes a regression from #622