### PR TITLE
Create an Intent for deep linking into Muzei's Sources screen

### DIFF
--- a/example-unsplash/build.gradle
+++ b/example-unsplash/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'kotlin-android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "androidx.activity:activity-ktx:$activityVersion"
     implementation "androidx.core:core-ktx:$coreVersion"
     implementation "androidx.work:work-runtime-ktx:$workManagerVersion"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/example-unsplash/src/main/AndroidManifest.xml
+++ b/example-unsplash/src/main/AndroidManifest.xml
@@ -27,6 +27,19 @@
         android:icon="@mipmap/source_ic_launcher"
         tools:ignore="GoogleAppIndexingWarning">
 
+        <activity-alias
+            android:name=".UnsplashLauncherActivity"
+            android:enabled="@bool/enable_launcher"
+            android:targetActivity=".UnsplashRedirectActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+        <activity
+            android:name=".UnsplashRedirectActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
         <service
             android:name="com.example.muzei.unsplash.UnsplashExampleArtSource"
             android:exported="false">

--- a/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashRedirectActivity.kt
+++ b/example-unsplash/src/main/java/com/example/muzei/unsplash/UnsplashRedirectActivity.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.muzei.unsplash
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.apps.muzei.api.MuzeiContract
+
+/**
+ * This activity's sole purpose is to redirect users to Muzei, which is where they should
+ * activate Muzei and then select the Unsplash source.
+ *
+ * You'll note the usage of the `enable_launcher` boolean resource value to only enable
+ * this on API 29+ devices as it is on API 29+ that a launcher icon becomes mandatory for
+ * every app.
+ */
+class UnsplashRedirectActivity : ComponentActivity() {
+    companion object {
+        private const val TAG = "UnsplashRedirect"
+        private const val MUZEI_PACKAGE_NAME = "net.nurik.roman.muzei"
+        private const val PLAY_STORE_LINK = "https://play.google.com/store/apps/details?id=$MUZEI_PACKAGE_NAME"
+    }
+
+    private val requestLauncher = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()) {
+        // It doesn't matter what the result is, the important part is that the
+        // user hit the back button to return to this activity. Since this activity
+        // has no UI of its own, we can simply finish the activity.
+        finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Build the list of Intents plus the Toast message that should be displayed
+        // to users when we successfully launch one of the Intents
+        val intents = listOf(
+                MuzeiContract.Sources.createChooseProviderIntent(BuildConfig.UNSPLASH_AUTHORITY)
+                        to R.string.toast_enable_unsplash,
+                packageManager.getLaunchIntentForPackage(MUZEI_PACKAGE_NAME)
+                        to R.string.toast_enable_unsplash_source,
+                Intent(Intent.ACTION_VIEW).setData(Uri.parse(PLAY_STORE_LINK))
+                        to R.string.toast_muzei_missing_error)
+        // Go through each Intent/message pair, trying each in turn
+        val success = intents.fold(false) { success, (intent, toastMessage) ->
+            if (success) {
+                // If one launch has succeeded, we don't need to
+                // try any further Intents
+                return@fold success
+            }
+            if (intent == null) {
+                // A null Intent means there's nothing to attempt to launch
+                return@fold false
+            }
+            try {
+                requestLauncher.launch(intent)
+                // Only if the launch succeeds do we show the Toast and trigger success
+                Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show()
+                true
+            } catch (e: Exception) {
+                Log.v(TAG, "Intent $intent failed", e)
+                false
+            }
+        }
+        if (!success) {
+            // Only if all Intents failed do we show a 'everything failed' Toast
+            Toast.makeText(this, R.string.toast_play_store_missing_error, Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/example-unsplash/src/main/res/values-v29/bools.xml
+++ b/example-unsplash/src/main/res/values-v29/bools.xml
@@ -15,5 +15,5 @@
   -->
 
 <resources>
-    <color name="colorPrimary">#FD9</color>
+    <bool name="enable_launcher">true</bool>
 </resources>

--- a/example-unsplash/src/main/res/values/bools.xml
+++ b/example-unsplash/src/main/res/values/bools.xml
@@ -15,5 +15,5 @@
   -->
 
 <resources>
-    <color name="colorPrimary">#FD9</color>
+    <bool name="enable_launcher">false</bool>
 </resources>

--- a/example-unsplash/src/main/res/values/strings.xml
+++ b/example-unsplash/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name"><xliff:g id="unsplash_name">Unsplash</xliff:g> (Example <xliff:g id="muzei_name">Muzei</xliff:g> Source)</string>
+    <string name="toast_enable_unsplash">Select <xliff:g id="unsplash_name">Unsplash</xliff:g> in <xliff:g id="muzei_name">Muzei</xliff:g></string>
+    <string name="toast_enable_unsplash_source">Select <xliff:g id="unsplash_name">Unsplash</xliff:g> from the list of Sources in <xliff:g id="muzei_name">Muzei</xliff:g></string>
+    <string name="toast_muzei_missing_error">You must install <xliff:g id="muzei_name">Muzei</xliff:g> to use this Source</string>
+    <string name="toast_play_store_missing_error">Could not install <xliff:g id="muzei_name">Muzei</xliff:g> from the <xliff:g id="google_play">Google Play</xliff:g> Store</string>
     <string name="name"><xliff:g id="unsplash_name">Unsplash</xliff:g> (Example)</string>
     <string name="description">Popular photos from <xliff:g id="unsplash_name">Unsplash</xliff:g></string>
     <string name="attribution">Photo on <xliff:g id="unsplash_name">Unsplash</xliff:g></string>

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -40,8 +40,7 @@
 
         <activity
             android:name="com.google.android.apps.muzei.MuzeiActivity"
-            android:theme="@style/Theme.MuzeiActivity"
-            android:launchMode="singleTop">
+            android:theme="@style/Theme.MuzeiActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -49,6 +48,7 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
             </intent-filter>
+            <nav-graph android:value="@navigation/main_navigation"/>
         </activity>
 
         <service

--- a/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ChooseProviderFragment.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.map
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.MergeAdapter
@@ -89,6 +90,8 @@ class ChooseProviderFragment : Fragment(R.layout.choose_provider_fragment) {
         private const val PLAY_STORE_PACKAGE_NAME = "com.android.vending"
     }
 
+    private val args: ChooseProviderFragmentArgs by navArgs()
+    private var scrolledToProvider = false
     private val viewModel: ChooseProviderViewModel by viewModels()
 
     private var startActivityProvider: String? = null
@@ -185,6 +188,16 @@ class ChooseProviderFragment : Fragment(R.layout.choose_provider_fragment) {
         viewModel.providers.observe(viewLifecycleOwner) {
             adapter.submitList(it) {
                 playStoreAdapter.shouldShow = true
+                if (args.authority != null && !scrolledToProvider) {
+                    val index = it.indexOfFirst { providerInfo ->
+                        providerInfo.authority == args.authority
+                    }
+                    if (index != -1) {
+                        scrolledToProvider = true
+                        requireArguments().remove("authority")
+                        binding.list.smoothScrollToPosition(index)
+                    }
+                }
             }
         }
         // Show a SnackBar whenever there are unsupported sources installed

--- a/main/src/main/res/navigation/main_navigation.xml
+++ b/main/src/main/res/navigation/main_navigation.xml
@@ -50,6 +50,13 @@
             android:name="com.google.android.apps.muzei.ChooseProviderFragment"
             android:label="@string/section_choose_source"
             tools:layout="@layout/choose_provider_fragment">
+            <argument
+                android:name="authority"
+                app:argType="string"
+                app:nullable="true"
+                android:defaultValue="@null" />
+            <deepLink
+                app:uri="muzei://sources/{authority}" />
             <action
                 android:id="@+id/browse"
                 app:destination="@+id/browse_provider"

--- a/muzei-api/build.gradle
+++ b/muzei-api/build.gradle
@@ -48,6 +48,8 @@ android {
         def apiVersion = versionProps['apiCode'].toInteger()
         manifestPlaceholders = [api_version: apiVersion]
         buildConfigField "int", "API_VERSION", "${apiVersion}"
+
+        buildConfigField "String", "CHOOSE_PROVIDER_URI_PREFIX", "\"muzei://sources/\""
     }
 
     buildTypes {

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.kt
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/MuzeiContract.kt
@@ -20,6 +20,7 @@ import android.content.ContentProvider
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
+import android.content.Intent
 import android.database.ContentObserver
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -335,5 +336,49 @@ object MuzeiContract {
         @Suppress("unused")
         fun ProviderClient.isSelected(context: Context) =
                 isProviderSelected(context, contentUri.authority!!)
+
+        /**
+         * Deep link into Muzei's Sources screen, automatically scrolling
+         * to the [com.google.android.apps.muzei.api.provider.MuzeiArtProvider] associated
+         * with the given [authority]. If Muzei is not yet activated, users will be asked
+         * to activate Muzei before continuing onto the Sources screen.
+         *
+         * Note that users must still manually select your `MuzeiArtProvider`.
+         *
+         * It is strongly recommended in cases where you receive an
+         * [android.content.ActivityNotFoundException] (due to the user having an older version
+         * of Muzei installed or if Muzei is not installed at all) to fall back on:
+         *
+         * 1. [android.content.pm.PackageManager.getLaunchIntentForPackage] with Muzei's
+         * package name, `net.nurik.roman.muzei` to open Muzei and navigate to the
+         * Sources screen themselves.
+         * 2. A link to the Google Play Store with Muzei's package name so that user can
+         * install Muzei.
+         */
+        @JvmStatic
+        fun createChooseProviderIntent(authority: String): Intent = Intent(Intent.ACTION_VIEW)
+                .setData(Uri.parse(BuildConfig.CHOOSE_PROVIDER_URI_PREFIX + authority))
     }
 }
+
+/**
+ * Deep link into Muzei's Sources screen, automatically scrolling
+ * to the [com.google.android.apps.muzei.api.provider.MuzeiArtProvider] associated
+ * with this [ProviderClient]. If Muzei is not yet activated, users will be asked
+ * to activate Muzei before continuing onto the Sources screen.
+ *
+ * Note that users must still manually select your `MuzeiArtProvider`.
+ *
+ * It is strongly recommended in cases where you receive an
+ * [android.content.ActivityNotFoundException] (due to the user having an older version
+ * of Muzei installed or if Muzei is not installed at all) to fall back on:
+ *
+ * 1. [android.content.pm.PackageManager.getLaunchIntentForPackage] with Muzei's
+ * package name, `net.nurik.roman.muzei` to open Muzei and navigate to the
+ * Sources screen themselves.
+ * 2. A link to the Google Play Store with Muzei's package name so that user can
+ * install Muzei.
+ */
+@Suppress("unused")
+fun ProviderClient.createChooseProviderIntent() =
+        MuzeiContract.Sources.createChooseProviderIntent(contentUri.authority!!)


### PR DESCRIPTION
The `createChooseProviderIntent()` method adds an official API for deep linking into Muzei's Sources screen, automatically scrolling to the provided `MuzeiArtProvider`.

Provided an example of how the Unsplash example source could use this to redirect users to Muzei's Sources screen from its launcher icon on API 29+ devices.

Fixes #659 