### PR TITLE
Fix Effects SeekBar titles being truncated

### DIFF
--- a/main/src/main/res/layout/effects_screen_fragment_include_content.xml
+++ b/main/src/main/res/layout/effects_screen_fragment_include_content.xml
@@ -29,7 +29,7 @@
         android:layout_marginBottom="16dp"
         android:text="@string/settings_blur_amount_title"
         app:layout_constraintBottom_toTopOf="@+id/dim_amount_title"
-        app:layout_constraintEnd_toEndOf="@+id/dim_amount_title"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
     <SeekBar
@@ -37,6 +37,7 @@
         style="@style/Settings.Widget.SeekBar.BlurAmount"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/settings_seek_bar_margin"
         android:max="500"
         app:layout_constraintBottom_toBottomOf="@+id/blur_amount_title"
         app:layout_constraintEnd_toEndOf="parent"
@@ -51,7 +52,7 @@
         android:layout_marginBottom="16dp"
         android:text="@string/settings_dim_amount_title"
         app:layout_constraintBottom_toTopOf="@+id/grey_amount_title"
-        app:layout_constraintEnd_toEndOf="@+id/grey_amount_title"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/blur_amount_title"/>
 
     <SeekBar
@@ -59,6 +60,7 @@
         style="@style/Settings.Widget.SeekBar.DimAmount"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/settings_seek_bar_margin"
         android:max="255"
         app:layout_constraintBottom_toBottomOf="@+id/dim_amount_title"
         app:layout_constraintEnd_toEndOf="parent"
@@ -80,6 +82,7 @@
         style="@style/Settings.Widget.SeekBar.GreyAmount"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/settings_seek_bar_margin"
         android:max="500"
         app:layout_constraintBottom_toBottomOf="@+id/grey_amount_title"
         app:layout_constraintEnd_toEndOf="parent"

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -36,6 +36,7 @@
     <dimen name="provider_padding_with_snackbar">56dp</dimen>
     <dimen name="settings_text_size_large">20sp</dimen>
     <dimen name="settings_text_size_normal">16sp</dimen>
+    <dimen name="settings_seek_bar_margin">8dp</dimen>
 
     <dimen name="tasker_action_icon_size">48dp</dimen>
 


### PR DESCRIPTION
Ensure that none of the titles appear partially offscreen. Also adds a small padding between the titles and SeekBars to ensure that they are readable.

Fixes #667