### PR TITLE
Implement Android 11's onZoomChanged()

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
@@ -219,6 +219,9 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
                 renderController.onLockScreen = isEffectsLockScreenOpen
             }.launchWhenStartedIn(this)
             ArtDetailOpen.onEach { isArtDetailOpened ->
+                if (isArtDetailOpened) {
+                    renderer.setZoom(0f)
+                }
                 cancelDelayedBlur()
                 queueEvent { renderer.setIsBlurred(!isArtDetailOpened, true) }
             }.launchWhenStartedIn(this)
@@ -294,6 +297,11 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
             super.onOffsetsChanged(xOffset, yOffset, xOffsetStep, yOffsetStep, xPixelOffset,
                     yPixelOffset)
             renderer.setNormalOffsetX(xOffset)
+        }
+
+        override fun onZoomChanged(zoom: Float) {
+            super.onZoomChanged(zoom)
+            renderer.setZoom(zoom)
         }
 
         override fun onCommand(

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
@@ -104,6 +104,8 @@ class MuzeiBlurRenderer(
 
     @Volatile
     private var normalOffsetX: Float = 0f
+    @Volatile
+    private var zoomAmount: Float = 0f
     private val currentViewport = RectF() // [-1, -1] to [1, 1], flipped
 
     var isBlurred = true
@@ -124,6 +126,7 @@ class MuzeiBlurRenderer(
         currentGLPictureSet = GLPictureSet(0)
         nextGLPictureSet = GLPictureSet(1) // for transitioning to next pictures
         setNormalOffsetX(0f)
+        setZoom(0f)
         recomputeMaxPrescaledBlurPixels()
         recomputeMaxDimAmount()
         recomputeGreyAmount()
@@ -244,6 +247,11 @@ class MuzeiBlurRenderer(
     @Keep
     fun setNormalOffsetX(x: Float) {
         normalOffsetX = x.constrain(0f, 1f)
+        onViewportChanged()
+    }
+
+    fun setZoom(zoom: Float) {
+        zoomAmount = 1f + zoom.constrain(0f, 1f) / 5f
         onViewportChanged()
     }
 
@@ -423,7 +431,7 @@ class MuzeiBlurRenderer(
             }
 
             // Ensure the bitmap is as wide as the screen by applying zoom if necessary
-            val zoom = max(1f, screenToBitmapAspectRatio)
+            val zoom = max(1f, screenToBitmapAspectRatio) * zoomAmount
 
             // Total scale factors in both zoom and scale due to aspect ratio.
             val scaledBitmapToScreenAspectRatio = zoom / screenToBitmapAspectRatio


### PR DESCRIPTION
Allow Muzei to react to the zoom level changing on Android 11 devices. This means that Muzei will zoom in slightly (20%) when the notification shade is pulled down or (at least when using the Pixel Launcher) when the app drawer is pulled up.

Fixes #681 