### PR TITLE
Immediately switch to lock screen effects

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
@@ -267,13 +267,13 @@ class MuzeiBlurRenderer(
         return maxPrescaledBlurPixels * blurInterpolator.getInterpolation(f / blurKeyframes)
     }
 
-    fun setAndConsumeImageLoader(imageLoader: ImageLoader) {
+    fun setAndConsumeImageLoader(imageLoader: ImageLoader, immediate: Boolean = false) {
         if (!surfaceCreated) {
             queuedNextImageLoader = imageLoader
             return
         }
 
-        if (crossfadeAnimator.isRunning) {
+        if (crossfadeAnimator.isRunning && !immediate) {
             queuedNextImageLoader = imageLoader
             return
         }
@@ -293,7 +293,7 @@ class MuzeiBlurRenderer(
 
         nextGLPictureSet.load(imageLoader)
 
-        crossfadeAnimator.start(0, 1) {
+        crossfadeAnimator.start(if (immediate) 1 else 0, 1) {
             // swap current and next picturesets
             val oldGLPictureSet = currentGLPictureSet
             currentGLPictureSet = nextGLPictureSet

--- a/main/src/main/java/com/google/android/apps/muzei/render/RenderController.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RenderController.kt
@@ -58,7 +58,8 @@ abstract class RenderController(
                         if (value) Prefs.PREF_LOCK_DIM_AMOUNT else Prefs.PREF_DIM_AMOUNT)
                 renderer.recomputeGreyAmount(
                         if (value) Prefs.PREF_LOCK_GREY_AMOUNT else Prefs.PREF_GREY_AMOUNT)
-                reloadCurrentArtwork()
+                // Switch immediately if we're transitioning to the lock screen
+                reloadCurrentArtwork(immediate = value)
             }
         }
     private lateinit var coroutineScope: CoroutineScope
@@ -125,7 +126,7 @@ abstract class RenderController(
 
     protected abstract suspend fun openDownloadedCurrentArtwork(): ImageLoader
 
-    fun reloadCurrentArtwork() {
+    fun reloadCurrentArtwork(immediate: Boolean = false) {
         if (destroyed) {
             // Don't reload artwork for destroyed RenderControllers
             return
@@ -134,8 +135,8 @@ abstract class RenderController(
             val imageLoader = openDownloadedCurrentArtwork()
 
             callbacks.queueEventOnGlThread {
-                if (visible) {
-                    renderer.setAndConsumeImageLoader(imageLoader)
+                if (visible || immediate) {
+                    renderer.setAndConsumeImageLoader(imageLoader, immediate)
                 } else {
                     queuedImageLoader = imageLoader
                 }


### PR DESCRIPTION
Rather than slowly transition to the lock screen effects, make the transition immediate. This avoids cases where the user quickly unlocks their device (i.e., via fingerprint / face unlock) and they see two transitions back to back.

This does not change the transition back to the home screen effects - that still transitions smoothly from the lock screen effects.

Fixes #554 