### PR TITLE
Fix provider item layout

### DIFF
--- a/main/src/main/res/layout/choose_provider_item.xml
+++ b/main/src/main/res/layout/choose_provider_item.xml
@@ -85,7 +85,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="bottom"
-            app:constraint_referenced_ids="artwork" />
+            app:constraint_referenced_ids="artwork,header" />
 
         <TextView
             android:id="@+id/description"


### PR DESCRIPTION
When the provider's image and description are not yet loaded, the layout is messed up - buttons on top of the name and icon. This fixes it.

![](https://user-images.githubusercontent.com/5629058/95683701-43f1b200-0bed-11eb-9a26-f292422c94d6.jpg)
