### PR TITLE
Cancel old command jobs to avoid command buttons targeting wrong artwork

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filterNotNull
@@ -151,6 +152,7 @@ class ArtDetailFragment : Fragment(R.layout.art_detail_fragment) {
 
     private var unsetNextFakeLoading: Job? = null
     private var showLoadingSpinner: Job? = null
+    private var loadCommandsJob: Job? = null
 
     init {
         lifecycleScope.launch {
@@ -388,7 +390,8 @@ class ArtDetailFragment : Fragment(R.layout.art_detail_fragment) {
                 }
             }
 
-            viewLifecycleOwner.lifecycleScope.launch {
+            loadCommandsJob?.cancel()
+            loadCommandsJob = viewLifecycleOwner.lifecycleScope.launch {
                 val commands = context?.run {
                     currentArtwork?.getCommands(this) ?: run {
                         if (viewModel.currentProvider.value?.authority == LEGACY_AUTHORITY) {
@@ -403,6 +406,7 @@ class ArtDetailFragment : Fragment(R.layout.art_detail_fragment) {
                         }
                     }
                 } ?: return@launch
+                ensureActive()
                 val activity = activity ?: return@launch
                 overflowSourceActionMap.clear()
                 binding.overflowMenu.menu.clear()

--- a/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/ArtDetailFragment.kt
@@ -77,6 +77,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -390,7 +391,7 @@ class ArtDetailFragment : Fragment(R.layout.art_detail_fragment) {
                 }
             }
 
-            loadCommandsJob?.cancel()
+            loadCommandsJob?.cancelAndJoin()
             loadCommandsJob = viewLifecycleOwner.lifecycleScope.launch {
                 val commands = context?.run {
                     currentArtwork?.getCommands(this) ?: run {


### PR DESCRIPTION
Currently, after my device has been idle and the wallpaper changed by Muzei, there is a probability (~33%) that the command buttons (e.g. Share, Bookmark, Show details) on the artwork in Muzei will actually operate on another image instead of the current one. The only button that always works correctly is clicking the artwork title, which always opens the correct art webpage.

I can confirm that this is not a bug of providers, as it also occurs with different providers. I believe this is caused by the device delivering multiple artwork updates after a long idle, which triggers a race in `ArtDetailFragment`.

By making sure only the latest job sets the commands, the issue is gone on my device.

<img width="1397" height="829" alt="image_2025-11-18_0" src="https://github.com/user-attachments/assets/68ee9b6b-3652-4662-b999-af81d6d83df0" />

