### PR TITLE
Fix legacy standalone build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,7 @@ paging-compose = { group = "androidx.paging", name = "paging-compose", version.r
 paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 recyclerView = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerView" }

--- a/legacy-standalone/build.gradle
+++ b/legacy-standalone/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     implementation libs.lifecycle.common
     implementation libs.lifecycle.runtime
     implementation libs.room.ktx
+    implementation libs.room.runtime
     ksp libs.room.compiler
     implementation libs.material
     implementation libs.firebase.analytics

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -249,22 +249,25 @@ class LegacySourceService : Service(), LifecycleOwner {
         var currentSource: Source? = null
 
         val database = LegacyDatabase.getInstance(this@LegacySourceService)
-        database.sourceDao().currentSource.collect { source ->
-            if (currentSource != null && source != null &&
-                    currentSource?.componentName == source.componentName) {
-                // Don't do anything if it is the same Source
-                return@collect
-            }
-            currentSource?.unsubscribe()
-            currentSource = source
-            if (source != null) {
-                source.subscribe()
-                send(source)
+        launch {
+            database.sourceDao().currentSource.collect { source ->
+                if (currentSource != null && source != null &&
+                        currentSource?.componentName == source?.componentName) {
+                    // Don't do anything if it is the same Source
+                    return@collect
+                }
+                currentSource?.unsubscribe()
+                currentSource = source
+                if (source != null) {
+                    source.subscribe()
+                    trySend(source)
+                }
             }
         }
-
         awaitClose {
-            currentSource?.unsubscribe()
+            runBlocking {
+                currentSource?.unsubscribe()
+            }
         }
     }
 

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -46,6 +46,9 @@ import com.google.android.apps.muzei.util.collectIn
 import com.google.android.apps.muzei.util.goAsync
 import com.google.android.apps.muzei.util.toast
 import com.google.android.apps.muzei.legacy.Source
+import com.google.android.apps.muzei.room.Source
+import com.google.android.apps.muzei.room.MuzeiDatabase
+import com.google.android.apps.muzei.room.SourceDao
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
 import kotlinx.coroutines.Dispatchers

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -130,7 +130,7 @@ class LegacySourceService : Service(), LifecycleOwner {
                         Log.d(TAG, "Got next artwork command")
                     }
                     val database = LegacyDatabase.getInstance(applicationContext)
-                    val source = database.sourceDao().getCurrentSource()
+                    val source: Source? = database.sourceDao().getCurrentSource()
                     if (source?.supportsNextArtwork == true) {
                         if (BuildConfig.DEBUG) {
                             Log.d(TAG, "Sending next artwork command to ${source.componentName}")

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -45,6 +45,7 @@ import com.google.android.apps.muzei.sources.SourceSubscriberService
 import com.google.android.apps.muzei.util.collectIn
 import com.google.android.apps.muzei.util.goAsync
 import com.google.android.apps.muzei.util.toast
+import com.google.android.apps.muzei.legacy.Source
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
 import kotlinx.coroutines.Dispatchers

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -55,6 +55,8 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.collect
 import net.nurik.roman.muzei.legacy.R
 import java.util.concurrent.Executors
 

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/LegacySourceService.kt
@@ -46,9 +46,7 @@ import com.google.android.apps.muzei.util.collectIn
 import com.google.android.apps.muzei.util.goAsync
 import com.google.android.apps.muzei.util.toast
 import com.google.android.apps.muzei.legacy.Source
-import com.google.android.apps.muzei.room.Source
 import com.google.android.apps.muzei.room.MuzeiDatabase
-import com.google.android.apps.muzei.room.SourceDao
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
 import kotlinx.coroutines.Dispatchers

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceDao.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceDao.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.Flow
 abstract class SourceDao {
 
     @get:Query("SELECT * FROM sources")
-    abstract val sources: Flow<List<Source>>
+    abstract val sourcesFlow: Flow<List<Source>>
 
     @Query("SELECT * FROM sources")
     abstract suspend fun getSources(): List<Source>
@@ -42,7 +42,7 @@ abstract class SourceDao {
     abstract suspend fun getSourceComponentNames(): List<ComponentName>
 
     @get:Query("SELECT * FROM sources WHERE selected=1 ORDER BY component_name")
-    abstract val currentSource: Flow<Source?>
+    abstract val currentSourceFlow: Flow<Source?>
 
     @get:Query("SELECT * FROM sources WHERE selected=1 ORDER BY component_name")
     abstract val currentSourceBlocking: Source?

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
@@ -39,6 +39,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import com.google.android.apps.muzei.legacy.Source
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
@@ -40,6 +40,9 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import com.google.android.apps.muzei.legacy.Source
+import com.google.android.apps.muzei.room.Source
+import com.google.android.apps.muzei.room.MuzeiDatabase
+import com.google.android.apps.muzei.room.SourceDao
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter

--- a/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
+++ b/legacy-standalone/src/main/java/com/google/android/apps/muzei/legacy/SourceSettingsActivity.kt
@@ -146,7 +146,7 @@ class SourceSettingsActivity : AppCompatActivity() {
                     finish()
                 }
                 .create()
-        val database = LegacyDatabase.getInstance(this)
+        val database = LegacyDatabase.getInstance(this).sourceDao()
         database.sourceDao().sources.collectIn(this) { sources ->
             if (sources.any { it.selected }) {
                 setResult(RESULT_OK)


### PR DESCRIPTION
```
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:35:13 Overload resolution ambiguity between candidates:
fun getSources(): Flow<List<Source>>
suspend fun getSources(): List<Source>
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:38:13 Overload resolution ambiguity between candidates:
fun getCurrentSource(): Flow<Source?>
suspend fun getCurrentSource(): Source?
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:191:11 Conflicting overloads:
suspend fun getSources(): List<Source>
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:191:15 Non-suspend function 'getSources' cannot override suspend function 'suspend fun getSources(): List<Source>' defined in 'com.google.android.apps.muzei.legacy.SourceDao'.
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:191:15 'getSources' hides member of supertype 'SourceDao' and needs an 'override' modifier.
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:277:27 Conflicting overloads:
fun getSources(): Flow<List<Source>>
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:393:11 Conflicting overloads:
suspend fun getCurrentSource(): Source?
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:393:15 Non-suspend function 'getCurrentSource' cannot override suspend function 'suspend fun getCurrentSource(): Source?' defined in 'com.google.android.apps.muzei.legacy.SourceDao'.
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:393:15 'getCurrentSource' hides member of supertype 'SourceDao' and needs an 'override' modifier.
e: file:///home/runner/work/MUZEIAPK/MUZEIAPK/input/legacy-standalone/build/generated/ksp/debug/kotlin/com/google/android/apps/muzei/legacy/SourceDao_Impl.kt:479:27 Conflicting overloads:
fun getCurrentSource(): Flow<Source?>
```