### PR TITLE
Add animated GIF wallpaper support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,9 @@ kotlin = "2.4.0"
 ksp = "2.3.7"
 
 # Other
+androidGifDrawable = "1.2.32"
 coil = "3.5.0"
+junit = "4.13.2"
 material = "1.14.0"
 okhttp = "5.4.0"
 okhttpCoroutines = "1.0"
@@ -133,9 +135,11 @@ dokka = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.r
 kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # Other
+android-gif-drawable = { group = "pl.droidsonroids.gif", name = "android-gif-drawable", version.ref = "androidGifDrawable" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-runtime = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
 coil-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 okhttp-core = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-coroutines = { group = "ru.gildor.coroutines", name = "kotlin-coroutines-okhttp", version.ref = "okhttpCoroutines" }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -112,6 +112,7 @@ dependencies {
     implementation libs.coil.okhttp
     implementation libs.wearable.playservices
     implementation libs.tasker
+    implementation libs.android.gif.drawable
     implementation libs.subsampling
     implementation libs.activity
     implementation libs.core
@@ -143,6 +144,8 @@ dependencies {
     implementation project(':source-gallery')
     implementation project(':source-single')
     implementation project(':gl-wallpaper')
+
+    testImplementation libs.junit
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/MuzeiWallpaperService.kt
@@ -25,6 +25,8 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.GestureDetector
 import android.view.MotionEvent
@@ -190,6 +192,8 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
                 gestureListener)
 
         private var delayedBlur: Job? = null
+        private val renderHandler = Handler(Looper.getMainLooper())
+        private val scheduledRender = Runnable { requestRender() }
 
         override fun onCreate(surfaceHolder: SurfaceHolder) {
             super<GLEngine>.onCreate(surfaceHolder)
@@ -272,12 +276,21 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
         }
 
         override fun onDestroy() {
+            cancelScheduledRender()
             wallpaperLifecycle.removeObserver(this)
             engineLifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
             queueEvent {
                 renderer.destroy()
             }
             super<GLEngine>.onDestroy()
+        }
+
+        override fun onSurfaceDestroyed(holder: SurfaceHolder) {
+            cancelScheduledRender()
+            queueEvent {
+                renderer.onSurfaceDestroyed()
+            }
+            super.onSurfaceDestroyed(holder)
         }
 
         fun lockScreenVisibleChanged(isLockScreenVisible: Boolean) {
@@ -287,6 +300,9 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
         }
 
         override fun onVisibilityChanged(visible: Boolean) {
+            if (!visible) {
+                cancelScheduledRender()
+            }
             renderController.visible = visible
         }
 
@@ -411,6 +427,15 @@ class MuzeiWallpaperService : GLWallpaperService(), LifecycleOwner {
             if (renderController.visible) {
                 super.requestRender()
             }
+        }
+
+        override fun scheduleRender(delayMillis: Long) {
+            renderHandler.removeCallbacks(scheduledRender)
+            renderHandler.postDelayed(scheduledRender, delayMillis.coerceAtLeast(0))
+        }
+
+        override fun cancelScheduledRender() {
+            renderHandler.removeCallbacks(scheduledRender)
         }
 
         override fun queueEventOnGlThread(event: () -> Unit) {

--- a/main/src/main/java/com/google/android/apps/muzei/render/AnimatedArtwork.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/AnimatedArtwork.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.render
+
+import android.graphics.Bitmap
+import android.opengl.GLES20
+import android.util.Log
+import com.google.android.apps.muzei.util.divideRoundUp
+import net.nurik.roman.muzei.BuildConfig
+import pl.droidsonroids.gif.GifAnimationMetaData
+import pl.droidsonroids.gif.GifOptions
+import pl.droidsonroids.gif.GifTexImage2D
+import pl.droidsonroids.gif.InputSource
+import java.io.BufferedInputStream
+import kotlin.math.max
+
+private const val GIF_HEADER_LENGTH = 6
+private const val MIN_FRAME_DELAY_MILLIS = 34L
+
+internal object GifHeaderDetector {
+    private val gif87a = "GIF87a".encodeToByteArray()
+    private val gif89a = "GIF89a".encodeToByteArray()
+
+    fun isGif(header: ByteArray, byteCount: Int = header.size): Boolean {
+        if (byteCount < GIF_HEADER_LENGTH) {
+            return false
+        }
+        return header.matches(gif87a) || header.matches(gif89a)
+    }
+
+    private fun ByteArray.matches(expected: ByteArray): Boolean {
+        for (index in expected.indices) {
+            if (this[index] != expected[index]) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+internal data class GifMetadata(
+        val width: Int,
+        val height: Int,
+        val frameCount: Int,
+        val loopCount: Int,
+        val durationMillis: Int
+)
+
+internal enum class ArtworkKind {
+    STATIC,
+    ANIMATED
+}
+
+internal fun classifyArtwork(hasGifHeader: Boolean, metadata: GifMetadata?): ArtworkKind =
+        if (hasGifHeader && metadata != null && metadata.frameCount > 1 &&
+                metadata.durationMillis > 0) {
+            ArtworkKind.ANIMATED
+        } else {
+            ArtworkKind.STATIC
+        }
+
+internal fun sanitizeGifFrameDelay(frameDelayMillis: Long): Long =
+        max(MIN_FRAME_DELAY_MILLIS, frameDelayMillis)
+
+internal fun calculateGifSampleSize(
+        metadata: GifMetadata,
+        targetWidth: Int,
+        targetHeight: Int,
+        maxTextureSize: Int
+): Int {
+    val widthSample = if (targetWidth > 0) metadata.width / targetWidth else 1
+    val heightSample = if (targetHeight > 0) metadata.height / targetHeight else 1
+    val textureSample = if (maxTextureSize > 0) {
+        max(
+                metadata.width.divideRoundUp(maxTextureSize),
+                metadata.height.divideRoundUp(maxTextureSize))
+    } else {
+        1
+    }
+    return max(1, max(textureSample, max(widthSample, heightSample)))
+}
+
+internal interface AnimatedArtworkDecoder : AutoCloseable {
+    val width: Int
+    val height: Int
+    val frameCount: Int
+    val loopCount: Int
+
+    fun frameDurationMillis(frameIndex: Int): Long
+    fun seekToFrame(frameIndex: Int)
+    fun uploadCurrentFrame()
+    fun updateTexture()
+}
+
+internal sealed interface DecodedArtwork {
+    val firstFrame: Bitmap
+
+    data class Static(override val firstFrame: Bitmap) : DecodedArtwork
+
+    data class Animated(
+            override val firstFrame: Bitmap,
+            val decoder: AnimatedArtworkDecoder
+    ) : DecodedArtwork
+}
+
+private class GifAnimatedArtworkDecoder(
+        private val gif: GifTexImage2D,
+        override val loopCount: Int
+) : AnimatedArtworkDecoder {
+    override val width: Int = gif.width
+    override val height: Int = gif.height
+    override val frameCount: Int = gif.numberOfFrames
+    private var closed = false
+
+    override fun frameDurationMillis(frameIndex: Int): Long =
+            gif.getFrameDuration(frameIndex).toLong()
+
+    override fun seekToFrame(frameIndex: Int) {
+        gif.seekToFrame(frameIndex)
+    }
+
+    override fun uploadCurrentFrame() {
+        gif.glTexImage2D(GLES20.GL_TEXTURE_2D, 0)
+    }
+
+    override fun updateTexture() {
+        gif.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0)
+    }
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            gif.recycle()
+        }
+    }
+}
+
+internal fun ImageLoader.decodeArtwork(
+        targetWidth: Int,
+        targetHeight: Int,
+        maxTextureSize: Int
+): DecodedArtwork? {
+    val firstFrame = decode(targetWidth, targetHeight) ?: return null
+    if (!hasGifHeader()) {
+        return DecodedArtwork.Static(firstFrame)
+    }
+
+    val metadata = readGifMetadata()
+    if (classifyArtwork(true, metadata) != ArtworkKind.ANIMATED || metadata == null) {
+        return DecodedArtwork.Static(firstFrame)
+    }
+
+    val decoder = try {
+        openGifDecoder(metadata, targetWidth, targetHeight, maxTextureSize)
+    } catch (exception: Exception) {
+        if (BuildConfig.DEBUG) {
+            Log.w("AnimatedArtwork", "Animated GIF decoding failed; using its first frame", exception)
+        }
+        null
+    }
+    return if (decoder != null) {
+        DecodedArtwork.Animated(firstFrame, decoder)
+    } else {
+        DecodedArtwork.Static(firstFrame)
+    }
+}
+
+private fun ImageLoader.hasGifHeader(): Boolean = try {
+    openInputStream()?.use { input ->
+        val header = ByteArray(GIF_HEADER_LENGTH)
+        var byteCount = 0
+        while (byteCount < header.size) {
+            val read = input.read(header, byteCount, header.size - byteCount)
+            if (read < 0) {
+                break
+            }
+            byteCount += read
+        }
+        GifHeaderDetector.isGif(header, byteCount)
+    } ?: false
+} catch (_: Exception) {
+    false
+}
+
+private fun ImageLoader.readGifMetadata(): GifMetadata? {
+    val input = openInputStream()?.let(::BufferedInputStream) ?: return null
+    return try {
+        val metadata = GifAnimationMetaData(input)
+        GifMetadata(
+                metadata.width,
+                metadata.height,
+                metadata.numberOfFrames,
+                metadata.loopCount,
+                metadata.duration)
+    } catch (exception: Exception) {
+        input.close()
+        if (BuildConfig.DEBUG) {
+            Log.w("AnimatedArtwork", "GIF metadata could not be read", exception)
+        }
+        null
+    }
+}
+
+private fun ImageLoader.openGifDecoder(
+        metadata: GifMetadata,
+        targetWidth: Int,
+        targetHeight: Int,
+        maxTextureSize: Int
+): AnimatedArtworkDecoder? {
+    val input = openInputStream()?.let(::BufferedInputStream) ?: return null
+    return try {
+        val options = GifOptions().apply {
+            setInSampleSize(calculateGifSampleSize(
+                    metadata, targetWidth, targetHeight, maxTextureSize))
+        }
+        val gif = GifTexImage2D(InputSource.InputStreamSource(input), options)
+        if (gif.width <= 0 || gif.height <= 0 || gif.numberOfFrames <= 1) {
+            gif.recycle()
+            null
+        } else {
+            GifAnimatedArtworkDecoder(gif, metadata.loopCount)
+        }
+    } catch (exception: Exception) {
+        input.close()
+        throw exception
+    }
+}
+
+internal class AnimatedArtworkPlayback(
+        val decoder: AnimatedArtworkDecoder
+) : AutoCloseable {
+    var currentFrameIndex = 0
+        private set
+    private var completedLoops = 0
+    private var nextFrameUptimeMillis = Long.MAX_VALUE
+    private var running = false
+    private var finished = false
+    private var closed = false
+
+    init {
+        require(decoder.frameCount > 1)
+    }
+
+    fun setVisible(visible: Boolean, nowUptimeMillis: Long) {
+        if (closed || finished || running == visible) {
+            return
+        }
+        running = visible
+        nextFrameUptimeMillis = if (visible) {
+            nowUptimeMillis + sanitizeGifFrameDelay(
+                    decoder.frameDurationMillis(currentFrameIndex))
+        } else {
+            Long.MAX_VALUE
+        }
+    }
+
+    fun advance(nowUptimeMillis: Long): Int? {
+        if (!running || nowUptimeMillis < nextFrameUptimeMillis) {
+            return null
+        }
+
+        var frameToRender: Int? = null
+        var framesAdvanced = 0
+        while (running && nowUptimeMillis >= nextFrameUptimeMillis) {
+            val nextFrame = currentFrameIndex + 1
+            if (nextFrame == decoder.frameCount) {
+                completedLoops++
+                if (decoder.loopCount > 0 && completedLoops >= decoder.loopCount) {
+                    running = false
+                    finished = true
+                    nextFrameUptimeMillis = Long.MAX_VALUE
+                    break
+                }
+                currentFrameIndex = 0
+            } else {
+                currentFrameIndex = nextFrame
+            }
+            frameToRender = currentFrameIndex
+            nextFrameUptimeMillis += sanitizeGifFrameDelay(
+                    decoder.frameDurationMillis(currentFrameIndex))
+
+            // Avoid spending an unbounded amount of time catching up after a stalled render.
+            framesAdvanced++
+            if (framesAdvanced >= decoder.frameCount * 2) {
+                nextFrameUptimeMillis = nowUptimeMillis + sanitizeGifFrameDelay(
+                        decoder.frameDurationMillis(currentFrameIndex))
+                break
+            }
+        }
+        return frameToRender
+    }
+
+    fun millisUntilNextFrame(nowUptimeMillis: Long): Long? =
+            if (running) max(0, nextFrameUptimeMillis - nowUptimeMillis) else null
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            running = false
+            nextFrameUptimeMillis = Long.MAX_VALUE
+            decoder.close()
+        }
+    }
+}
+
+internal class AnimatedArtworkSlot : AutoCloseable {
+    var playback: AnimatedArtworkPlayback? = null
+        private set
+
+    fun replace(next: AnimatedArtworkPlayback?) {
+        if (playback === next) {
+            return
+        }
+        playback?.close()
+        playback = next
+    }
+
+    override fun close() {
+        replace(null)
+    }
+}

--- a/main/src/main/java/com/google/android/apps/muzei/render/GLPicture.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/GLPicture.kt
@@ -31,9 +31,14 @@ internal fun Bitmap.toGLPicture(): GLPicture? {
     return GLPicture(this)
 }
 
-internal class GLPicture @SuppressLint("CheckResult") internal constructor(
-        bitmap: Bitmap
+internal class GLPicture @SuppressLint("CheckResult") private constructor(
+        private val bitmap: Bitmap?,
+        private val animatedDecoder: AnimatedArtworkDecoder?
 ) {
+
+    internal constructor(bitmap: Bitmap) : this(bitmap, null)
+
+    internal constructor(animatedDecoder: AnimatedArtworkDecoder) : this(null, animatedDecoder)
 
     companion object {
         private const val VERTEX_SHADER_CODE = "" +
@@ -83,6 +88,8 @@ internal class GLPicture @SuppressLint("CheckResult") internal constructor(
         private var UNIFORM_MVP_MATRIX_HANDLE: Int = 0
 
         private var TILE_SIZE: Int = 0
+        var maxTextureSize: Int = 0
+            private set
 
         fun initGl() {
             // Initialize shaders and create/link program
@@ -99,6 +106,7 @@ internal class GLPicture @SuppressLint("CheckResult") internal constructor(
             // Compute max texture size
             val maxTextureSize = IntArray(1)
             GLES20.glGetIntegerv(GLES20.GL_MAX_TEXTURE_SIZE, maxTextureSize, 0)
+            this.maxTextureSize = maxTextureSize[0]
             TILE_SIZE = min(512, maxTextureSize[0])
         }
     }
@@ -109,41 +117,61 @@ internal class GLPicture @SuppressLint("CheckResult") internal constructor(
 
     private val numColumns: Int
     private val numRows: Int
-    private val width = bitmap.width
-    private val height = bitmap.height
+    private val width = bitmap?.width ?: requireNotNull(animatedDecoder).width
+    private val height = bitmap?.height ?: requireNotNull(animatedDecoder).height
+    private val tileWidth = if (animatedDecoder != null) width else TILE_SIZE
+    private val tileHeight = if (animatedDecoder != null) height else TILE_SIZE
     private val textureHandles: IntArray
 
     init {
-        val leftoverHeight = height % TILE_SIZE
-
-        // Load m x n textures
-        numColumns = width.divideRoundUp(TILE_SIZE)
-        numRows = height.divideRoundUp(TILE_SIZE)
-
-        textureHandles = IntArray(numColumns * numRows)
-        if (numColumns == 1 && numRows == 1) {
-            textureHandles[0] = GLUtil.loadTexture(bitmap)
+        if (animatedDecoder != null) {
+            numColumns = 1
+            numRows = 1
+            textureHandles = IntArray(1)
+            animatedDecoder.seekToFrame(0)
+            textureHandles[0] = GLUtil.loadTexture(animatedDecoder::uploadCurrentFrame)
         } else {
-            val rect = Rect()
-            for (y in 0 until numRows) {
-                for (x in 0 until numColumns) {
-                    rect.set(x * TILE_SIZE,
-                            (numRows - y - 1) * TILE_SIZE,
-                            (x + 1) * TILE_SIZE,
-                            (numRows - y) * TILE_SIZE)
-                    // The bottom tiles must be full tiles for drawing, so only allow edge tiles
-                    // at the top
-                    if (leftoverHeight > 0) {
-                        rect.offset(0, -TILE_SIZE + leftoverHeight)
+            val staticBitmap = requireNotNull(bitmap)
+            val leftoverHeight = height % TILE_SIZE
+
+            // Load m x n textures
+            numColumns = width.divideRoundUp(TILE_SIZE)
+            numRows = height.divideRoundUp(TILE_SIZE)
+
+            textureHandles = IntArray(numColumns * numRows)
+            if (numColumns == 1 && numRows == 1) {
+                textureHandles[0] = GLUtil.loadTexture(staticBitmap)
+            } else {
+                val rect = Rect()
+                for (y in 0 until numRows) {
+                    for (x in 0 until numColumns) {
+                        rect.set(x * TILE_SIZE,
+                                (numRows - y - 1) * TILE_SIZE,
+                                (x + 1) * TILE_SIZE,
+                                (numRows - y) * TILE_SIZE)
+                        // The bottom tiles must be full tiles for drawing, so only allow edge tiles
+                        // at the top
+                        if (leftoverHeight > 0) {
+                            rect.offset(0, -TILE_SIZE + leftoverHeight)
+                        }
+                        rect.intersect(0, 0, width, height)
+                        val subBitmap = Bitmap.createBitmap(staticBitmap,
+                                rect.left, rect.top, rect.width(), rect.height())
+                        textureHandles[y * numColumns + x] = GLUtil.loadTexture(subBitmap)
+                        subBitmap.recycle()
                     }
-                    rect.intersect(0, 0, width, height)
-                    val subBitmap = Bitmap.createBitmap(bitmap,
-                            rect.left, rect.top, rect.width(), rect.height())
-                    textureHandles[y * numColumns + x] = GLUtil.loadTexture(subBitmap)
-                    subBitmap.recycle()
                 }
             }
         }
+    }
+
+    fun updateAnimatedFrame(frameIndex: Int) {
+        val decoder = animatedDecoder ?: return
+        decoder.seekToFrame(frameIndex)
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureHandles[0])
+        GLUtil.checkGlError("Bind animated artwork texture")
+        decoder.updateTexture()
+        GLUtil.checkGlError("Update animated artwork texture")
     }
 
     fun draw(mvpMatrix: FloatArray, alpha: Float) {
@@ -175,16 +203,16 @@ internal class GLPicture @SuppressLint("CheckResult") internal constructor(
         for (y in 0 until numRows) {
             for (x in 0 until numColumns) {
                 // Pass in the vertex information
-                vertices[9] = min(-1 + 2f * x.toFloat() * TILE_SIZE.toFloat() / width, 1f)
+                vertices[9] = min(-1 + 2f * x.toFloat() * tileWidth.toFloat() / width, 1f)
                 vertices[3] = vertices[9]
                 vertices[0] = vertices[3] // left
-                vertices[16] = min(-1 + 2f * (y + 1).toFloat() * TILE_SIZE.toFloat() / height, 1f)
+                vertices[16] = min(-1 + 2f * (y + 1).toFloat() * tileHeight.toFloat() / height, 1f)
                 vertices[10] = vertices[16]
                 vertices[1] = vertices[10] // top
-                vertices[15] = min(-1 + 2f * (x + 1).toFloat() * TILE_SIZE.toFloat() / width, 1f)
+                vertices[15] = min(-1 + 2f * (x + 1).toFloat() * tileWidth.toFloat() / width, 1f)
                 vertices[12] = vertices[15]
                 vertices[6] = vertices[12] // right
-                vertices[13] = min(-1 + 2f * y.toFloat() * TILE_SIZE.toFloat() / height, 1f)
+                vertices[13] = min(-1 + 2f * y.toFloat() * tileHeight.toFloat() / height, 1f)
                 vertices[7] = vertices[13]
                 vertices[4] = vertices[7] // bottom
                 vertexBuffer.put(vertices)

--- a/main/src/main/java/com/google/android/apps/muzei/render/GLUtil.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/GLUtil.kt
@@ -67,6 +67,13 @@ object GLUtil {
     }
 
     fun loadTexture(bitmap: Bitmap): Int {
+        return loadTexture {
+            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
+            checkGlError("texImage2D")
+        }
+    }
+
+    fun loadTexture(upload: () -> Unit): Int {
         val textureHandle = IntArray(1)
 
         GLES20.glGenTextures(1, textureHandle, 0)
@@ -86,9 +93,7 @@ object GLUtil {
             GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER,
                     GLES20.GL_LINEAR)
 
-            // Load the bitmap into the bound texture.
-            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
-            checkGlError("texImage2D")
+            upload()
         }
 
         if (textureHandle[0] == 0) {

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiBlurRenderer.kt
@@ -23,6 +23,7 @@ import android.graphics.RectF
 import android.opengl.GLES20
 import android.opengl.GLSurfaceView
 import android.opengl.Matrix
+import android.os.SystemClock
 import android.util.Log
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.annotation.Keep
@@ -98,6 +99,7 @@ class MuzeiBlurRenderer(
     private var queuedNextImageLoader: ImageLoader? = null
 
     private var surfaceCreated: Boolean = false
+    private var visible: Boolean = false
 
     @Volatile
     private var normalOffsetX: Float = 0f
@@ -209,6 +211,9 @@ class MuzeiBlurRenderer(
     }
 
     fun hintViewportSize(width: Int, height: Int) {
+        if (width <= 0 || height <= 0) {
+            return
+        }
         currentHeight = height
         aspectRatio = width * 1f / height
     }
@@ -217,6 +222,10 @@ class MuzeiBlurRenderer(
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
 
         Matrix.setIdentityM(modelMatrix, 0)
+
+        val nowUptimeMillis = SystemClock.uptimeMillis()
+        currentGLPictureSet.advanceAnimation(nowUptimeMillis)
+        nextGLPictureSet.advanceAnimation(nowUptimeMillis)
 
         val stillAnimating = crossfadeAnimator.tick() or blurAnimator.tick()
 
@@ -237,7 +246,18 @@ class MuzeiBlurRenderer(
         colorOverlay.draw(modelMatrix) // don't need any perspective or anything for color overlay
 
         if (stillAnimating) {
+            callbacks.cancelScheduledRender()
             callbacks.requestRender()
+        } else {
+            val nextFrameDelay = listOfNotNull(
+                    currentGLPictureSet.millisUntilNextFrame(nowUptimeMillis),
+                    nextGLPictureSet.millisUntilNextFrame(nowUptimeMillis))
+                    .minOrNull()
+            if (nextFrameDelay != null) {
+                callbacks.scheduleRender(nextFrameDelay)
+            } else {
+                callbacks.cancelScheduledRender()
+            }
         }
     }
 
@@ -270,10 +290,17 @@ class MuzeiBlurRenderer(
             return
         }
 
+        if (currentHeight <= 0) {
+            queuedNextImageLoader = imageLoader
+            return
+        }
+
         if (crossfadeAnimator.isRunning && !immediate) {
             queuedNextImageLoader = imageLoader
             return
         }
+
+        queuedNextImageLoader = null
 
         val (width, height) = imageLoader.getSize()
         if (width == 0 || height == 0) {
@@ -305,7 +332,6 @@ class MuzeiBlurRenderer(
             if (!demoMode) {
                 SwitchingPhotosStateFlow.value = SwitchingPhotosDone(currentGLPictureSet.id)
             }
-            System.gc()
             val loader = queuedNextImageLoader
             if (loader != null) {
                 queuedNextImageLoader = null
@@ -319,6 +345,7 @@ class MuzeiBlurRenderer(
         private val projectionMatrix = FloatArray(16)
         private val mvpMatrix = FloatArray(16)
         private val pictures = arrayOfNulls<GLPicture>(blurKeyframes + 1)
+        private val animatedArtwork = AnimatedArtworkSlot()
         private var hasBitmap = false
         private var bitmapAspectRatio = 1f
         var dimAmount = 0
@@ -345,17 +372,47 @@ class MuzeiBlurRenderer(
                     (maxDim * (1 - DIM_RANGE + DIM_RANGE * sqrt(darkness.toDouble()))).toInt()
                 tempBitmap?.recycle()
 
-                // Create the GLPicture objects
+                // Create the original GLPicture. Animated GIFs replace only this texture;
+                // blurred keyframes below remain based on the first frame.
                 var success = false
                 var sampleSize = 1
                 do {
-                    val attemptedWidth = (bitmapAspectRatio * currentHeight / sampleSize).toInt()
-                    val attemptedHeight = currentHeight / sampleSize
+                    val attemptedWidth = max(1,
+                            (bitmapAspectRatio * currentHeight / sampleSize).toInt())
+                    val attemptedHeight = max(1, currentHeight / sampleSize)
                     try {
-                        val image = imageLoader.decode(
+                        val artwork = imageLoader.decodeArtwork(
                                 attemptedWidth,
-                                attemptedHeight)
-                        pictures[0] = image?.toGLPicture()
+                                attemptedHeight,
+                                GLPicture.maxTextureSize)
+                        if (artwork != null) {
+                            try {
+                                when (artwork) {
+                                    is DecodedArtwork.Static -> {
+                                        pictures[0] = artwork.firstFrame.toGLPicture()
+                                    }
+                                    is DecodedArtwork.Animated -> {
+                                        try {
+                                            pictures[0] = GLPicture(artwork.decoder)
+                                            AnimatedArtworkPlayback(artwork.decoder).also { playback ->
+                                                playback.setVisible(visible, SystemClock.uptimeMillis())
+                                                animatedArtwork.replace(playback)
+                                            }
+                                        } catch (error: OutOfMemoryError) {
+                                            artwork.decoder.close()
+                                            throw error
+                                        } catch (exception: Exception) {
+                                            artwork.decoder.close()
+                                            pictures[0] = artwork.firstFrame.toGLPicture()
+                                            Log.w(TAG, "Could not create animated GIF texture; using first frame",
+                                                    exception)
+                                        }
+                                    }
+                                }
+                            } finally {
+                                artwork.firstFrame.recycle()
+                            }
+                        }
                         success = true
                     } catch (_: OutOfMemoryError) {
                         sampleSize = sampleSize shl 1
@@ -549,19 +606,77 @@ class MuzeiBlurRenderer(
             }
         }
 
-        fun destroyPictures() {
-            for (i in pictures.indices) {
-                if (pictures[i] != null) {
-                    pictures[i]?.destroy()
-                    pictures[i] = null
+        fun advanceAnimation(nowUptimeMillis: Long) {
+            val playback = animatedArtwork.playback ?: return
+            try {
+                playback.advance(nowUptimeMillis)?.let { frameIndex ->
+                    pictures[0]?.updateAnimatedFrame(frameIndex)
                 }
+            } catch (exception: Exception) {
+                Log.w(TAG, "Animated GIF playback failed; keeping the last rendered frame",
+                        exception)
+                animatedArtwork.close()
             }
+        }
+
+        fun millisUntilNextFrame(nowUptimeMillis: Long): Long? =
+                animatedArtwork.playback?.millisUntilNextFrame(nowUptimeMillis)
+
+        fun setVisible(visible: Boolean, nowUptimeMillis: Long) {
+            try {
+                animatedArtwork.playback?.setVisible(visible, nowUptimeMillis)
+            } catch (exception: Exception) {
+                Log.w(TAG, "Animated GIF could not resume; keeping the last rendered frame",
+                        exception)
+                animatedArtwork.close()
+            }
+        }
+
+        fun destroyPictures(deleteTextures: Boolean = true) {
+            if (deleteTextures) {
+                pictures.filterNotNull().toSet().forEach(GLPicture::destroy)
+            }
+            for (i in pictures.indices) {
+                pictures[i] = null
+            }
+            animatedArtwork.close()
         }
     }
 
+    fun setVisible(visible: Boolean) {
+        this.visible = visible
+        val nowUptimeMillis = SystemClock.uptimeMillis()
+        currentGLPictureSet.setVisible(visible, nowUptimeMillis)
+        nextGLPictureSet.setVisible(visible, nowUptimeMillis)
+        if (visible) {
+            callbacks.requestRender()
+        } else {
+            callbacks.cancelScheduledRender()
+        }
+    }
+
+    fun onSurfaceDestroyed() {
+        surfaceCreated = false
+        currentHeight = 0
+        aspectRatio = 0f
+        callbacks.cancelScheduledRender()
+        // EGL teardown owns texture cleanup when the surface/context is already going away.
+        currentGLPictureSet.destroyPictures(deleteTextures = false)
+        nextGLPictureSet.destroyPictures(deleteTextures = false)
+    }
+
     fun destroy() {
-        currentGLPictureSet.destroyPictures()
-        nextGLPictureSet.destroyPictures()
+        if (surfaceCreated) {
+            surfaceCreated = false
+            currentHeight = 0
+            aspectRatio = 0f
+            callbacks.cancelScheduledRender()
+            currentGLPictureSet.destroyPictures()
+            nextGLPictureSet.destroyPictures()
+        } else {
+            onSurfaceDestroyed()
+        }
+        queuedNextImageLoader = null
     }
 
     fun setIsBlurred(isBlurred: Boolean, artDetailMode: Boolean) {
@@ -573,15 +688,13 @@ class MuzeiBlurRenderer(
 
         blurRelatedToArtDetailMode = artDetailMode
         this.isBlurred = isBlurred
-        blurAnimator.start(endValue = if (isBlurred) blurKeyframes else 0) {
-            if (isBlurred && artDetailMode) {
-                System.gc()
-            }
-        }
+        blurAnimator.start(endValue = if (isBlurred) blurKeyframes else 0) { }
         callbacks.requestRender()
     }
 
-    fun interface Callbacks {
+    interface Callbacks {
         fun requestRender()
+        fun scheduleRender(delayMillis: Long)
+        fun cancelScheduledRender()
     }
 }

--- a/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/MuzeiRendererFragment.kt
@@ -82,6 +82,7 @@ class MuzeiRendererFragment : Fragment(), RenderController.Callbacks, MuzeiBlurR
     private lateinit var simpleDemoModeImageView: ImageView
     private var demoMode: Boolean = false
     private var demoFocus: Boolean = false
+    private val scheduledRender = Runnable { requestRender() }
 
     private val simpleDemoModeTransformation = object : Transformation() {
         override suspend fun transform(
@@ -148,11 +149,14 @@ class MuzeiRendererFragment : Fragment(), RenderController.Callbacks, MuzeiBlurR
     }
 
     override fun onDestroyView() {
+        cancelScheduledRender()
         super.onDestroyView()
         muzeiView = null
     }
 
     override fun onPause() {
+        cancelScheduledRender()
+        muzeiView?.renderController?.visible = false
         super.onPause()
         muzeiView?.onPause()
     }
@@ -160,6 +164,7 @@ class MuzeiRendererFragment : Fragment(), RenderController.Callbacks, MuzeiBlurR
     override fun onResume() {
         super.onResume()
         muzeiView?.onResume()
+        muzeiView?.renderController?.visible = !isHidden
     }
 
     override fun queueEventOnGlThread(event: () -> Unit) {
@@ -170,6 +175,17 @@ class MuzeiRendererFragment : Fragment(), RenderController.Callbacks, MuzeiBlurR
 
     override fun requestRender() {
         muzeiView?.requestRender()
+    }
+
+    override fun scheduleRender(delayMillis: Long) {
+        muzeiView?.run {
+            removeCallbacks(scheduledRender)
+            postDelayed(scheduledRender, delayMillis.coerceAtLeast(0))
+        }
+    }
+
+    override fun cancelScheduledRender() {
+        muzeiView?.removeCallbacks(scheduledRender)
     }
 
     private inner class MuzeiView(context: Context) : GLTextureView(context) {

--- a/main/src/main/java/com/google/android/apps/muzei/render/RenderController.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/render/RenderController.kt
@@ -42,14 +42,17 @@ abstract class RenderController(
     var visible: Boolean = false
         set(value) {
             field = value
-            if (value) {
-                callbacks.queueEventOnGlThread {
+            callbacks.queueEventOnGlThread {
+                renderer.setVisible(value)
+                if (value) {
                     val loader = queuedImageLoader
                     if (loader != null) {
                         queuedImageLoader = null
                         renderer.setAndConsumeImageLoader(loader)
                     }
                 }
+            }
+            if (value) {
                 callbacks.requestRender()
             }
         }

--- a/main/src/test/java/com/google/android/apps/muzei/render/AnimatedArtworkTest.kt
+++ b/main/src/test/java/com/google/android/apps/muzei/render/AnimatedArtworkTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.apps.muzei.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnimatedArtworkTest {
+
+    @Test
+    fun gifHeaderDetectionUsesContent() {
+        assertTrue(GifHeaderDetector.isGif("GIF87a-more".encodeToByteArray()))
+        assertTrue(GifHeaderDetector.isGif("GIF89a-more".encodeToByteArray()))
+        assertFalse(GifHeaderDetector.isGif("\u0089PNG\r\n".encodeToByteArray()))
+        assertFalse(GifHeaderDetector.isGif("GIF".encodeToByteArray()))
+    }
+
+    @Test
+    fun staticImagesAndSingleFrameGifsAreStatic() {
+        val animatedMetadata = GifMetadata(20, 20, 2, 0, 200)
+        val singleFrameMetadata = GifMetadata(20, 20, 1, 1, 100)
+
+        assertEquals(ArtworkKind.STATIC, classifyArtwork(false, animatedMetadata))
+        assertEquals(ArtworkKind.STATIC, classifyArtwork(true, singleFrameMetadata))
+        assertEquals(ArtworkKind.ANIMATED, classifyArtwork(true, animatedMetadata))
+    }
+
+    @Test
+    fun decoderFailureFallsBackToStaticClassification() {
+        assertEquals(ArtworkKind.STATIC, classifyArtwork(true, null))
+        assertEquals(
+                ArtworkKind.STATIC,
+                classifyArtwork(true, GifMetadata(20, 20, 2, 0, 0)))
+    }
+
+    @Test
+    fun frameDelayIsCappedAtThirtyFramesPerSecond() {
+        assertEquals(34L, sanitizeGifFrameDelay(0))
+        assertEquals(34L, sanitizeGifFrameDelay(10))
+        assertEquals(50L, sanitizeGifFrameDelay(50))
+    }
+
+    @Test
+    fun largeGifIsSampledTowardTargetAndTextureLimits() {
+        val metadata = GifMetadata(8000, 4000, 2, 0, 200)
+
+        assertEquals(4, calculateGifSampleSize(metadata, 2000, 1000, 4096))
+        assertEquals(8, calculateGifSampleSize(metadata, 1000, 500, 4096))
+    }
+
+    @Test
+    fun playbackSchedulesFramesFromTheirDeadlines() {
+        val playback = AnimatedArtworkPlayback(FakeDecoder(
+                frameDurations = longArrayOf(40, 50),
+                loopCount = 1))
+
+        playback.setVisible(true, 100)
+        assertEquals(40L, playback.millisUntilNextFrame(100))
+        assertNull(playback.advance(139))
+        assertEquals(1, playback.advance(140))
+        assertEquals(50L, playback.millisUntilNextFrame(140))
+        assertNull(playback.advance(190))
+        assertNull(playback.millisUntilNextFrame(190))
+    }
+
+    @Test
+    fun playbackHonorsFiniteLoopCount() {
+        val playback = AnimatedArtworkPlayback(FakeDecoder(
+                frameDurations = longArrayOf(34, 34),
+                loopCount = 2))
+
+        playback.setVisible(true, 0)
+        assertEquals(1, playback.advance(34))
+        assertEquals(0, playback.advance(68))
+        assertEquals(1, playback.advance(102))
+        assertNull(playback.advance(136))
+        assertNull(playback.millisUntilNextFrame(136))
+        playback.setVisible(true, 200)
+        assertNull(playback.millisUntilNextFrame(200))
+    }
+
+    @Test
+    fun playbackPausesAndRestartsDeadlineWhenVisibleAgain() {
+        val playback = AnimatedArtworkPlayback(FakeDecoder(longArrayOf(10, 10)))
+
+        playback.setVisible(true, 0)
+        playback.setVisible(false, 10)
+        assertNull(playback.millisUntilNextFrame(10))
+        playback.setVisible(true, 100)
+        assertEquals(34L, playback.millisUntilNextFrame(100))
+    }
+
+    @Test
+    fun replacingArtworkClosesOldDecoder() {
+        val firstDecoder = FakeDecoder(longArrayOf(40, 40))
+        val secondDecoder = FakeDecoder(longArrayOf(40, 40))
+        val slot = AnimatedArtworkSlot()
+
+        slot.replace(AnimatedArtworkPlayback(firstDecoder))
+        slot.replace(AnimatedArtworkPlayback(secondDecoder))
+        assertTrue(firstDecoder.closed)
+        assertFalse(secondDecoder.closed)
+
+        slot.close()
+        assertTrue(secondDecoder.closed)
+    }
+
+    private class FakeDecoder(
+            private val frameDurations: LongArray,
+            override val loopCount: Int = 0
+    ) : AnimatedArtworkDecoder {
+        override val width = 20
+        override val height = 20
+        override val frameCount = frameDurations.size
+        var closed = false
+
+        override fun frameDurationMillis(frameIndex: Int) = frameDurations[frameIndex]
+        override fun seekToFrame(frameIndex: Int) = Unit
+        override fun uploadCurrentFrame() = Unit
+        override fun updateTexture() = Unit
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
Summary
Adds support for animated GIF wallpapers in Muzei.

What’s included
- Detects animated GIFs via content inspection
- Uses android-gif-drawable for efficient decoding
- Animates GIFs using a single reused OpenGL texture (no per-frame allocations)
- Frame scheduling capped (~30 FPS) with safe delay handling
- Lifecycle-aware playback (pause/resume/cleanup)
- Falls back to static rendering if decoding fails

Rendering behavior
- Animated GIF plays when wallpaper is active
- Blur/dim uses first frame (to avoid heavy per-frame processing)
- Existing transitions, zoom, and dimming preserved

Performance considerations
- No continuous rendering loop (respects Muzei render model)
- No excessive allocations
- Avoids catch-up bursts on startup
- Scales decoding to reasonable size

Testing
- Verified on physical device
- Tested large and small GIFs
- Verified lifecycle behavior (home, app switch, screen off/on)

Notes
- Static images unaffected
- Existing behavior preserved